### PR TITLE
feat!: Allow passing body_json as keyword arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+test.py

--- a/openapi-client-template/client.py.jinja
+++ b/openapi-client-template/client.py.jinja
@@ -22,7 +22,7 @@ class APIStub:
         if not hasattr(imp, self._exec_mode):
             return APIStub(client=self._client, mod=imp, exec=self._exec_mode)
 
-        return partial(getattr(imp, self._exec_mode), client=self._client)
+        return partial(getattr(imp, self._exec_mode), _client=self._client)
 
 
 @attr.s(auto_attribs=True)

--- a/openapi-client-template/endpoint_macros.py.jinja
+++ b/openapi-client-template/endpoint_macros.py.jinja
@@ -1,0 +1,229 @@
+{% from "property_templates/helpers.jinja" import guarded_statement %}
+{% from "helpers.jinja" import safe_docstring %}
+
+{% macro header_params(endpoint) %}
+{% if endpoint.header_parameters %}
+    {% for parameter in endpoint.header_parameters.values() %}
+        {% set destination = 'headers["' +  parameter.name + '"]' %}
+        {% import "property_templates/" + parameter.template as param_template %}
+        {% if param_template.transform_header %}
+            {% set statement = param_template.transform_header(parameter, parameter.python_name, destination) %}
+        {% else %}
+            {% set statement = destination + " = " + parameter.python_name %}
+        {% endif %}
+{{ guarded_statement(parameter, parameter.python_name, statement) }}
+    {% endfor %}
+{% endif %}
+{% endmacro %}
+
+{% macro cookie_params(endpoint) %}
+{% if endpoint.cookie_parameters %}
+    {% for parameter in endpoint.cookie_parameters.values() %}
+        {% if parameter.required %}
+cookies["{{ parameter.name}}"] = {{ parameter.python_name }}
+        {% else %}
+if {{ parameter.python_name }} is not UNSET:
+    cookies["{{ parameter.name}}"] = {{ parameter.python_name }}
+        {% endif %}
+    {% endfor %}
+{% endif %}
+{% endmacro %}
+
+
+{% macro query_params(endpoint) %}
+{% if endpoint.query_parameters %}
+params: Dict[str, Any] = {}
+{% for property in endpoint.query_parameters.values() %}
+    {% set destination = property.python_name %}
+    {% import "property_templates/" + property.template as prop_template %}
+    {% if prop_template.transform %}
+        {% set destination = "json_" + property.python_name %}
+{{ prop_template.transform(property, property.python_name, destination) }}
+    {% endif %}
+    {%- if not property.json_is_dict %}
+params["{{ property.name }}"] = {{ destination }}
+    {% else %}
+{{ guarded_statement(property, destination, "params.update(" + destination + ")") }}
+    {% endif %}
+
+
+{% endfor %}
+
+params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+{% endif %}
+{% endmacro %}
+
+{% macro json_body(endpoint) %}
+{% if endpoint.json_body %}
+    {% set property = endpoint.json_body %}
+    {% set destination = "json_" + property.python_name %}
+    {% import "property_templates/" + property.template as prop_template %}
+    {% if prop_template.transform %}
+{{ prop_template.transform(property, property.python_name, destination, transform_method="dict") }}
+    {% else %}
+{{ destination }} = {{ property.python_name }}
+    {% endif %}
+{% endif %}
+{% endmacro %}
+
+{% macro multipart_body(endpoint) %}
+{% if endpoint.multipart_body %}
+    {% set property = endpoint.multipart_body %}
+    {% set destination = "multipart_" + property.python_name %}
+    {% import "property_templates/" + property.template as prop_template %}
+    {% if prop_template.transform_multipart %}
+{{ prop_template.transform_multipart(property, property.python_name, destination) }}
+    {% endif %}
+{% endif %}
+{% endmacro %}
+
+{# The all the kwargs passed into an endpoint (and variants thereof)) #}
+{% macro arguments(endpoint) %}
+{# path parameters #}
+{% for parameter in endpoint.path_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+*,
+{# Proper client based on whether or not the endpoint requires authentication #}
+{% if endpoint.requires_security %}
+_client: AuthenticatedClient,
+{% else %}
+_client: Client,
+{% endif %}
+{# Form data if any #}
+{% if endpoint.form_body %}
+form_data: {{ endpoint.form_body.get_type_string() }},
+{% endif %}
+{# Multipart data if any #}
+{% if endpoint.multipart_body %}
+multipart_data: {{ endpoint.multipart_body.get_type_string() }},
+{% endif %}
+{# JSON body if any #}
+{% if endpoint.json_body %}
+**json_body: {{ endpoint.json_body.get_type_string() }},
+{% endif %}
+{# query parameters #}
+{% for parameter in endpoint.query_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+{% for parameter in endpoint.header_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+{# cookie parameters #}
+{% for parameter in endpoint.cookie_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+{% endmacro %}
+
+{# The all the kwargs passed into an endpoint (and variants thereof)) #}
+{% macro kwarguments(endpoint) %}
+{# path parameters #}
+{% for parameter in endpoint.path_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+*,
+{# Proper client based on whether or not the endpoint requires authentication #}
+{% if endpoint.requires_security %}
+_client: AuthenticatedClient,
+{% else %}
+_client: Client,
+{% endif %}
+{# Form data if any #}
+{% if endpoint.form_body %}
+form_data: {{ endpoint.form_body.get_type_string() }},
+{% endif %}
+{# Multipart data if any #}
+{% if endpoint.multipart_body %}
+multipart_data: {{ endpoint.multipart_body.get_type_string() }},
+{% endif %}
+{# JSON body if any #}
+{% if endpoint.json_body %}
+json_body: {{ endpoint.json_body.get_type_string() }},
+{% endif %}
+{# query parameters #}
+{% for parameter in endpoint.query_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+{% for parameter in endpoint.header_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+{# cookie parameters #}
+{% for parameter in endpoint.cookie_parameters.values() %}
+{{ parameter.to_string() }},
+{% endfor %}
+{% endmacro %}
+
+{# Just lists all kwargs to endpoints as name=name for passing to other functions #}
+{% macro kwargs(endpoint) %}
+{% for parameter in endpoint.path_parameters.values() %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+_client=_client,
+{% if endpoint.form_body %}
+form_data=form_data,
+{% endif %}
+{% if endpoint.multipart_body %}
+multipart_data=multipart_data,
+{% endif %}
+{% if endpoint.json_body %}
+json_body=json_body,
+{% endif %}
+{% for parameter in endpoint.query_parameters.values() %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+{% for parameter in endpoint.header_parameters.values() %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+{% for parameter in endpoint.cookie_parameters.values() %}
+{{ parameter.python_name }}={{ parameter.python_name }},
+{% endfor %}
+{% endmacro %}
+
+{# Process Pydantic model inputs #}
+{% macro type_casting(endpoint) %}
+{% if endpoint.form_body %}
+form_data = {{ endpoint.form_data.get_type_string() }}(**form_data)
+{% endif %}
+{% if endpoint.multipart_body %}
+multipart_data = {{ endpoint.multipart_data.get_type_string() }}(**multipart_data)
+{% endif %}
+{% if endpoint.json_body %}
+json_body = {{ endpoint.json_body.get_type_string() }}(**json_body)
+{% endif %}
+{% endmacro %}
+
+
+{% macro docstring_content(endpoint, return_string, is_detailed) %}
+{% if endpoint.summary %}{{ endpoint.summary | wordwrap(100)}}
+
+{% endif -%}
+{%- if endpoint.description %} {{ endpoint.description | wordwrap(100) }}
+
+{% endif %}
+{% if not endpoint.summary and not endpoint.description %}
+{# Leave extra space so that Args or Returns isn't at the top #}
+
+{% endif %}
+{% set all_parameters = endpoint.list_all_parameters() %}
+{% if all_parameters %}
+Args:
+    {% for parameter in all_parameters %}
+    {{ parameter.to_docstring() | wordwrap(90) | indent(8) }}
+    {% endfor %}
+
+{% endif %}
+Raises:
+    errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+    httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+Returns:
+{% if is_detailed %}
+    Response[{{ return_string }}]
+{% else %}
+    {{ return_string }}
+{% endif %}
+{% endmacro %}
+
+{% macro docstring(endpoint, return_string, is_detailed) %}
+{{ safe_docstring(docstring_content(endpoint, return_string, is_detailed)) }}
+{% endmacro %}

--- a/openapi-client-template/endpoint_module.py.jinja
+++ b/openapi-client-template/endpoint_module.py.jinja
@@ -1,0 +1,148 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+{% for relative in endpoint.relative_imports %}
+{{ relative }}
+{% endfor %}
+
+{% from "endpoint_macros.py.jinja" import header_params, cookie_params, query_params, json_body, multipart_body,
+    arguments, client, kwargs, kwarguments, type_casting, parse_response, docstring %}
+
+{% set return_string = endpoint.response_type() %}
+{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
+
+def _get_kwargs(
+    {{ kwarguments(endpoint) | indent(4) }}
+) -> Dict[str, Any]:
+    url = "{}{{ endpoint.path }}".format(
+        _client.base_url
+        {%- for parameter in endpoint.path_parameters.values() -%}
+        ,{{parameter.name}}={{parameter.python_name}}
+        {%- endfor -%}
+    )
+
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
+
+    {{ header_params(endpoint) | indent(4) }}
+
+    {{ cookie_params(endpoint) | indent(4) }}
+
+    {{ query_params(endpoint) | indent(4) }}
+
+    {{ json_body(endpoint) | indent(4) }}
+
+    {{ multipart_body(endpoint) | indent(4) }}
+
+    return {
+	    "method": "{{ endpoint.method }}",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
+        {% if endpoint.form_body %}
+        "data": form_data.to_dict(),
+        {% elif endpoint.multipart_body %}
+        "files": {{ "multipart_" + endpoint.multipart_body.python_name }},
+        {% elif endpoint.json_body %}
+        "json": {{ "json_" + endpoint.json_body.python_name }},
+        {% endif %}
+        {% if endpoint.query_parameters %}
+        "params": params,
+        {% endif %}
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[{{ return_string }}]:
+    {% for response in endpoint.responses %}
+    if response.status_code == HTTPStatus.{{ response.status_code.name }}:
+        {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
+        {% if prop_template.construct %}
+        {{ prop_template.construct(response.prop, response.source) | indent(8) }}
+        {% else %}
+        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source }})
+        {% endif %}
+        return {{ response.prop.python_name }}
+        {% else %}
+        return None
+        {% endif %}
+    {% endfor %}
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[{{ return_string }}]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    {{ type_casting(endpoint) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint) }}
+    )
+
+    response = httpx.request(
+        verify=_client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=_client, response=response)
+
+{% if parsed_responses %}
+def sync(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return sync_detailed(
+        {{ kwargs(endpoint) }}
+    ).parsed
+{% endif %}
+
+async def asyncio_detailed(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Response[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+
+    {{ type_casting(endpoint) }}
+
+    kwargs = _get_kwargs(
+        {{ kwargs(endpoint) }}
+    )
+
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(
+            **kwargs
+        )
+
+    return _build_response(client=_client, response=response)
+
+{% if parsed_responses %}
+async def asyncio(
+    {{ arguments(endpoint) | indent(4) }}
+) -> Optional[{{ return_string }}]:
+    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+
+    return (await asyncio_detailed(
+        {{ kwargs(endpoint) }}
+    )).parsed
+{% endif %}

--- a/openapi-client-template/model.py.jinja
+++ b/openapi-client-template/model.py.jinja
@@ -1,0 +1,149 @@
+from typing import Any, Dict, Type, TypeVar, Tuple, Optional, BinaryIO, TextIO, TYPE_CHECKING
+
+{% if model.additional_properties %}
+from typing import List
+
+{% endif %}
+
+import attr
+{% if model.is_multipart_body %}
+import json
+{% endif %}
+
+from pydantic import BaseModel, Field
+
+from ..types import UNSET, Unset
+
+{% for relative in model.relative_imports %}
+{{ relative }}
+{% endfor %}
+
+{% for lazy_import in model.lazy_imports %}
+{{ lazy_import }}
+{% endfor %}
+
+
+{% if model.additional_properties %}
+{% set additional_property_type = 'Any' if model.additional_properties == True else model.additional_properties.get_type_string(quoted=not model.additional_properties.is_base_type) %}
+{% endif %}
+
+{% set class_name = model.class_info.name %}
+{% set module_name = model.class_info.module_name %}
+
+{% from "helpers.jinja" import safe_docstring %}
+
+T = TypeVar("T", bound="{{ class_name }}")
+
+{% macro class_docstring_content(model) %}
+    {% if model.title %}{{ model.title | wordwrap(116) }}
+
+    {% endif -%}
+    {%- if model.description %}{{ model.description | wordwrap(116) }}
+
+    {% endif %}
+    {% if not model.title and not model.description %}
+    {# Leave extra space so that a section doesn't start on the first line #}
+
+    {% endif %}
+    {% if model.example %}
+    Example:
+        {{ model.example | string | wordwrap(112) | indent(12) }}
+
+    {% endif %}
+    {% if model.required_properties or model.optional_properties %}
+    Attributes:
+    {% for property in model.required_properties + model.optional_properties %}
+        {{ property.to_docstring() | wordwrap(112) | indent(12) }}
+    {% endfor %}{% endif %}
+{% endmacro %}
+
+class {{ class_name }}(BaseModel):
+    {{ safe_docstring(class_docstring_content(model)) | indent(4) }}
+
+    {% for property in model.required_properties + model.optional_properties %}
+    {% if property.default is none and property.required %}
+    {{ property.to_string() }} = Field(alias="{{ property.name }}")
+    {% endif %}
+    {% endfor %}
+    {% for property in model.required_properties + model.optional_properties %}
+    {% if property.default is not none or not property.required %}
+    {{ property.to_string() }}
+    {% endif %}
+    {% endfor %}
+    {% if model.additional_properties %}
+    additional_properties: Dict[str, {{ additional_property_type }}] = {}
+    {% endif %}
+
+{% macro _to_dict(multipart=False) %}
+{% for property in model.required_properties + model.optional_properties %}
+{% import "property_templates/" + property.template as prop_template %}
+{% if prop_template.transform %}
+{{ prop_template.transform(property, "self." + property.python_name, property.python_name, multipart=multipart) }}
+{% elif multipart %}
+{{ property.python_name }} = self.{{ property.python_name }} if isinstance(self.{{ property.python_name }}, Unset) else (None, str(self.{{ property.python_name }}).encode(), "text/plain")
+{% else %}
+{{ property.python_name }} = self.{{ property.python_name }}
+{% endif %}
+{% endfor %}
+
+field_dict: Dict[str, Any] = {}
+{% if model.additional_properties %}
+{% if model.additional_properties.template %}{# Can be a bool instead of an object #}
+    {% import "property_templates/" + model.additional_properties.template as prop_template %}
+{% else %}
+    {% set prop_template = None %}
+{% endif %}
+{% if prop_template and prop_template.transform %}
+for prop_name, prop in self.additional_properties.items():
+    {{ prop_template.transform(model.additional_properties, "prop", "field_dict[prop_name]", multipart=multipart, declare_type=false) | indent(4) }}
+{% elif multipart %}
+field_dict.update({
+    key: (None, str(value).encode(), "text/plain")
+    for key, value in self.additional_properties.items()
+})
+{% else %}
+field_dict.update(self.additional_properties)
+{% endif %}
+{% endif %}
+field_dict.update({
+    {% for property in model.required_properties + model.optional_properties %}
+    {% if property.required %}
+    "{{ property.name }}": {{ property.python_name }},
+    {% endif %}
+    {% endfor %}
+})
+{% for property in model.optional_properties %}
+{% if not property.required %}
+if {{ property.python_name }} is not UNSET:
+    field_dict["{{ property.name }}"] = {{ property.python_name }}
+{% endif %}
+{% endfor %}
+
+return field_dict
+{% endmacro %}
+
+{% if model.is_multipart_body %}
+    def to_multipart(self) -> Dict[str, Any]:
+        {{ _to_dict(multipart=True) | indent(8) }}
+{% endif %}
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    {% if model.additional_properties %}
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> {{ additional_property_type }}:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: {{ additional_property_type }}) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties
+    {% endif %}

--- a/openapi-client-template/model_property.py.jinja
+++ b/openapi-client-template/model_property.py.jinja
@@ -1,0 +1,40 @@
+{% macro construct_function(property, source) %}
+{{ property.class_info.name }}(**{{ source }})
+{% endmacro %}
+
+{% from "property_templates/property_macros.py.jinja" import construct_template %}
+
+{% macro construct(property, source, initial_value=None) %}
+{{ construct_template(construct_function, property, source, initial_value=initial_value) }}
+{% endmacro %}
+
+{% macro check_type_for_construct(property, source) %}isinstance({{ source }}, dict){% endmacro %}
+
+{% macro transform(property, source, destination, declare_type=True, multipart=False, transform_method="to_dict") %}
+{% set transformed = source + "." + transform_method + "()" %}
+{% if multipart %}
+    {% set transformed = "(None, json.dumps(" + transformed + ").encode(), 'application/json')" %}
+    {% set type_string = "Union[Unset, Tuple[None, bytes, str]]" %}
+{% else %}
+    {% set type_string = property.get_type_string(json=True) %}
+{% endif %}
+{% if property.required %}
+{% if property.nullable %}
+{{ destination }} = {{ transformed }} if {{ source }} else None
+{% else %}
+{{ destination }} = {{ transformed }}
+{% endif %}
+{% else %}
+{{ destination }}{% if declare_type %}: {{ type_string }}{% endif %} = UNSET
+if not isinstance({{ source }}, Unset):
+{% if property.nullable %}
+    {{ destination }} = {{ transformed }} if {{ source }} else None
+{% else %}
+    {{ destination }} = {{ transformed }}
+{% endif %}
+{% endif %}
+{% endmacro %}
+
+{% macro transform_multipart(property, source, destination) %}
+{{ transform(property, source, destination, transform_method="to_multipart") }}
+{% endmacro %}

--- a/openapi-client-template/property_templates/model_property.py.jinja
+++ b/openapi-client-template/property_templates/model_property.py.jinja
@@ -1,0 +1,41 @@
+{% macro construct_function(property, source) %}
+{{ property.class_info.name }}.update_forward_refs()
+{{ property.class_info.name }}(**{{ source }})
+{% endmacro %}
+
+{% from "property_templates/property_macros.py.jinja" import construct_template %}
+
+{% macro construct(property, source, initial_value=None) %}
+{{ construct_template(construct_function, property, source, initial_value=initial_value) }}
+{% endmacro %}
+
+{% macro check_type_for_construct(property, source) %}isinstance({{ source }}, dict){% endmacro %}
+
+{% macro transform(property, source, destination, declare_type=True, multipart=False, transform_method="to_dict") %}
+{% set transformed = source + "." + transform_method + "()" %}
+{% if multipart %}
+    {% set transformed = "(None, json.dumps(" + transformed + ").encode(), 'application/json')" %}
+    {% set type_string = "Union[Unset, Tuple[None, bytes, str]]" %}
+{% else %}
+    {% set type_string = property.get_type_string(json=True) %}
+{% endif %}
+{% if property.required %}
+{% if property.nullable %}
+{{ destination }} = {{ transformed }} if {{ source }} else None
+{% else %}
+{{ destination }} = {{ transformed }}
+{% endif %}
+{% else %}
+{{ destination }}{% if declare_type %}: {{ type_string }}{% endif %} = UNSET
+if not isinstance({{ source }}, Unset):
+{% if property.nullable %}
+    {{ destination }} = {{ transformed }} if {{ source }} else None
+{% else %}
+    {{ destination }} = {{ transformed }}
+{% endif %}
+{% endif %}
+{% endmacro %}
+
+{% macro transform_multipart(property, source, destination) %}
+{{ transform(property, source, destination, transform_method="to_multipart") }}
+{% endmacro %}

--- a/poetry.lock
+++ b/poetry.lock
@@ -418,7 +418,7 @@ testing = ["pytest", "pytest-benchmark"]
 name = "pydantic"
 version = "1.10.7"
 description = "Data validation and settings management using python type hints"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -626,7 +626,7 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -637,4 +637,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "93d6f4b6505c6f1cfbf220a132db41ed09b937720c54950afe5f8674613fcc85"
+content-hash = "76e71fd4f353b3713a99d23790fff509c9c981ebc48ab082d0f3501a0e33b38c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "spacetraders"}]
 [tool.poetry.dependencies]
 python = "^3.11"
 httpx = "^0.24.0"
+pydantic = "^1.10.7"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/spacetraders/api/agents/get_my_agent.py
+++ b/spacetraders/api/agents/get_my_agent.py
@@ -11,20 +11,20 @@ from ...types import UNSET, Response
 
 def _get_kwargs(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
-    url = "{}/my/agent".format(client.base_url)
+    url = "{}/my/agent".format(_client.base_url)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -32,7 +32,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetMyAgentResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetMyAgentResponse200.from_dict(response.json())
+        response_200 = GetMyAgentResponse200.update_forward_refs()
+        GetMyAgentResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -54,7 +55,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMyAgentResponse200]:
     """My Agent Details
 
@@ -69,20 +70,20 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMyAgentResponse200]:
     """My Agent Details
 
@@ -97,13 +98,13 @@ def sync(
     """
 
     return sync_detailed(
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMyAgentResponse200]:
     """My Agent Details
 
@@ -118,18 +119,18 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMyAgentResponse200]:
     """My Agent Details
 
@@ -145,6 +146,6 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/contracts/accept_contract.py
+++ b/spacetraders/api/contracts/accept_contract.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/contracts/{contractId}/accept".format(
-        client.base_url, contractId=contract_id
+        _client.base_url, contractId=contract_id
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[AcceptContractResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = AcceptContractResponse200.from_dict(response.json())
+        response_200 = AcceptContractResponse200.update_forward_refs()
+        AcceptContractResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[AcceptContractResponse200]:
     """Accept Contract
 
@@ -77,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[AcceptContractResponse200]:
     """Accept Contract
 
@@ -110,14 +111,14 @@ def sync(
 
     return sync_detailed(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[AcceptContractResponse200]:
     """Accept Contract
 
@@ -136,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[AcceptContractResponse200]:
     """Accept Contract
 
@@ -168,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             contract_id=contract_id,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/contracts/deliver_contract.py
+++ b/spacetraders/api/contracts/deliver_contract.py
@@ -13,25 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: DeliverContractJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/my/contracts/{contractId}/deliver".format(
-        client.base_url, contractId=contract_id
+        _client.base_url, contractId=contract_id
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -40,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[DeliverContractResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = DeliverContractResponse200.from_dict(response.json())
+        response_200 = DeliverContractResponse200.update_forward_refs()
+        DeliverContractResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -63,8 +64,8 @@ def _build_response(
 def sync_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
-    json_body: DeliverContractJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: DeliverContractJsonBody,
 ) -> Response[DeliverContractResponse200]:
     """Deliver Contract
 
@@ -82,25 +83,27 @@ def sync_detailed(
         Response[DeliverContractResponse200]
     """
 
+    json_body = DeliverContractJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
-    json_body: DeliverContractJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: DeliverContractJsonBody,
 ) -> Optional[DeliverContractResponse200]:
     """Deliver Contract
 
@@ -120,7 +123,7 @@ def sync(
 
     return sync_detailed(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -128,8 +131,8 @@ def sync(
 async def asyncio_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
-    json_body: DeliverContractJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: DeliverContractJsonBody,
 ) -> Response[DeliverContractResponse200]:
     """Deliver Contract
 
@@ -147,23 +150,25 @@ async def asyncio_detailed(
         Response[DeliverContractResponse200]
     """
 
+    json_body = DeliverContractJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
-    json_body: DeliverContractJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: DeliverContractJsonBody,
 ) -> Optional[DeliverContractResponse200]:
     """Deliver Contract
 
@@ -184,7 +189,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             contract_id=contract_id,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/contracts/fulfill_contract.py
+++ b/spacetraders/api/contracts/fulfill_contract.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/contracts/{contractId}/fulfill".format(
-        client.base_url, contractId=contract_id
+        _client.base_url, contractId=contract_id
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[FulfillContractResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = FulfillContractResponse200.from_dict(response.json())
+        response_200 = FulfillContractResponse200.update_forward_refs()
+        FulfillContractResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[FulfillContractResponse200]:
     """Fulfill Contract
 
@@ -77,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[FulfillContractResponse200]:
     """Fulfill Contract
 
@@ -110,14 +111,14 @@ def sync(
 
     return sync_detailed(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[FulfillContractResponse200]:
     """Fulfill Contract
 
@@ -136,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[FulfillContractResponse200]:
     """Fulfill Contract
 
@@ -168,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             contract_id=contract_id,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/contracts/get_contract.py
+++ b/spacetraders/api/contracts/get_contract.py
@@ -12,20 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
-    url = "{}/my/contracts/{contractId}".format(client.base_url, contractId=contract_id)
+    url = "{}/my/contracts/{contractId}".format(
+        _client.base_url, contractId=contract_id
+    )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -33,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetContractResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetContractResponse200.from_dict(response.json())
+        response_200 = GetContractResponse200.update_forward_refs()
+        GetContractResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -56,7 +59,7 @@ def _build_response(
 def sync_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetContractResponse200]:
     """Get Contract
 
@@ -75,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetContractResponse200]:
     """Get Contract
 
@@ -108,14 +111,14 @@ def sync(
 
     return sync_detailed(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetContractResponse200]:
     """Get Contract
 
@@ -134,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         contract_id=contract_id,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     contract_id: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetContractResponse200]:
     """Get Contract
 
@@ -166,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             contract_id=contract_id,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/contracts/get_contracts.py
+++ b/spacetraders/api/contracts/get_contracts.py
@@ -11,14 +11,14 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/my/contracts".format(client.base_url)
+    url = "{}/my/contracts".format(_client.base_url)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     params: Dict[str, Any] = {}
     params["page"] = page
@@ -32,8 +32,8 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "params": params,
     }
 
@@ -42,7 +42,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetContractsResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetContractsResponse200.from_dict(response.json())
+        response_200 = GetContractsResponse200.update_forward_refs()
+        GetContractsResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -64,7 +65,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetContractsResponse200]:
@@ -85,22 +86,22 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetContractsResponse200]:
@@ -121,7 +122,7 @@ def sync(
     """
 
     return sync_detailed(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     ).parsed
@@ -129,7 +130,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetContractsResponse200]:
@@ -150,20 +151,20 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetContractsResponse200]:
@@ -185,7 +186,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            client=client,
+            _client=_client,
             page=page,
             limit=limit,
         )

--- a/spacetraders/api/default/register.py
+++ b/spacetraders/api/default/register.py
@@ -12,23 +12,23 @@ from ...types import UNSET, Response
 
 def _get_kwargs(
     *,
-    client: Client,
+    _client: Client,
     json_body: RegisterJsonBody,
 ) -> Dict[str, Any]:
-    url = "{}/register".format(client.base_url)
+    url = "{}/register".format(_client.base_url)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -37,7 +37,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[RegisterResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = RegisterResponse201.from_dict(response.json())
+        response_201 = RegisterResponse201.update_forward_refs()
+        RegisterResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -59,8 +60,8 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: Client,
-    json_body: RegisterJsonBody,
+    _client: Client,
+    **json_body: RegisterJsonBody,
 ) -> Response[RegisterResponse201]:
     """Register New Agent
 
@@ -99,23 +100,25 @@ def sync_detailed(
         Response[RegisterResponse201]
     """
 
+    json_body = RegisterJsonBody(**json_body)
+
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     *,
-    client: Client,
-    json_body: RegisterJsonBody,
+    _client: Client,
+    **json_body: RegisterJsonBody,
 ) -> Optional[RegisterResponse201]:
     """Register New Agent
 
@@ -155,15 +158,15 @@ def sync(
     """
 
     return sync_detailed(
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
-    client: Client,
-    json_body: RegisterJsonBody,
+    _client: Client,
+    **json_body: RegisterJsonBody,
 ) -> Response[RegisterResponse201]:
     """Register New Agent
 
@@ -202,21 +205,23 @@ async def asyncio_detailed(
         Response[RegisterResponse201]
     """
 
+    json_body = RegisterJsonBody(**json_body)
+
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     *,
-    client: Client,
-    json_body: RegisterJsonBody,
+    _client: Client,
+    **json_body: RegisterJsonBody,
 ) -> Optional[RegisterResponse201]:
     """Register New Agent
 
@@ -257,7 +262,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/factions/get_faction.py
+++ b/spacetraders/api/factions/get_faction.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     faction_symbol: str = "CGR",
     *,
-    client: Client,
+    _client: Client,
 ) -> Dict[str, Any]:
     url = "{}/factions/{factionSymbol}".format(
-        client.base_url, factionSymbol=faction_symbol
+        _client.base_url, factionSymbol=faction_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetFactionResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetFactionResponse200.from_dict(response.json())
+        response_200 = GetFactionResponse200.update_forward_refs()
+        GetFactionResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     faction_symbol: str = "CGR",
     *,
-    client: Client,
+    _client: Client,
 ) -> Response[GetFactionResponse200]:
     """Get Faction
 
@@ -77,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         faction_symbol=faction_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     faction_symbol: str = "CGR",
     *,
-    client: Client,
+    _client: Client,
 ) -> Optional[GetFactionResponse200]:
     """Get Faction
 
@@ -110,14 +111,14 @@ def sync(
 
     return sync_detailed(
         faction_symbol=faction_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     faction_symbol: str = "CGR",
     *,
-    client: Client,
+    _client: Client,
 ) -> Response[GetFactionResponse200]:
     """Get Faction
 
@@ -136,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         faction_symbol=faction_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     faction_symbol: str = "CGR",
     *,
-    client: Client,
+    _client: Client,
 ) -> Optional[GetFactionResponse200]:
     """Get Faction
 
@@ -168,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             faction_symbol=faction_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/factions/get_factions.py
+++ b/spacetraders/api/factions/get_factions.py
@@ -11,14 +11,14 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    client: Client,
+    _client: Client,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/factions".format(client.base_url)
+    url = "{}/factions".format(_client.base_url)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     params: Dict[str, Any] = {}
     params["page"] = page
@@ -32,8 +32,8 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "params": params,
     }
 
@@ -42,7 +42,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetFactionsResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetFactionsResponse200.from_dict(response.json())
+        response_200 = GetFactionsResponse200.update_forward_refs()
+        GetFactionsResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -64,7 +65,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: Client,
+    _client: Client,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetFactionsResponse200]:
@@ -85,22 +86,22 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     *,
-    client: Client,
+    _client: Client,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetFactionsResponse200]:
@@ -121,7 +122,7 @@ def sync(
     """
 
     return sync_detailed(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     ).parsed
@@ -129,7 +130,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: Client,
+    _client: Client,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetFactionsResponse200]:
@@ -150,20 +151,20 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     *,
-    client: Client,
+    _client: Client,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetFactionsResponse200]:
@@ -185,7 +186,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            client=client,
+            _client=_client,
             page=page,
             limit=limit,
         )

--- a/spacetraders/api/fleet/create_chart.py
+++ b/spacetraders/api/fleet/create_chart.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/chart".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[CreateChartResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = CreateChartResponse201.from_dict(response.json())
+        response_201 = CreateChartResponse201.update_forward_refs()
+        CreateChartResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateChartResponse201]:
     """Create Chart
 
@@ -82,21 +83,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateChartResponse201]:
     """Create Chart
 
@@ -120,14 +121,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateChartResponse201]:
     """Create Chart
 
@@ -151,19 +152,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateChartResponse201]:
     """Create Chart
 
@@ -188,6 +189,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/create_ship_ship_scan.py
+++ b/spacetraders/api/fleet/create_ship_ship_scan.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/scan/ships".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[CreateShipShipScanResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = CreateShipShipScanResponse201.from_dict(response.json())
+        response_201 = CreateShipShipScanResponse201.update_forward_refs()
+        CreateShipShipScanResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateShipShipScanResponse201]:
     """Scan Ships
 
@@ -77,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateShipShipScanResponse201]:
     """Scan Ships
 
@@ -110,14 +111,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateShipShipScanResponse201]:
     """Scan Ships
 
@@ -136,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateShipShipScanResponse201]:
     """Scan Ships
 
@@ -168,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/create_ship_system_scan.py
+++ b/spacetraders/api/fleet/create_ship_system_scan.py
@@ -14,22 +14,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/scan/systems".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -37,7 +37,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[CreateShipSystemScanResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = CreateShipSystemScanResponse201.from_dict(response.json())
+        response_201 = CreateShipSystemScanResponse201.update_forward_refs()
+        CreateShipSystemScanResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -60,7 +61,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateShipSystemScanResponse201]:
     """Scan Systems
 
@@ -79,21 +80,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateShipSystemScanResponse201]:
     """Scan Systems
 
@@ -112,14 +113,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateShipSystemScanResponse201]:
     """Scan Systems
 
@@ -138,19 +139,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateShipSystemScanResponse201]:
     """Scan Systems
 
@@ -170,6 +171,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/create_ship_waypoint_scan.py
+++ b/spacetraders/api/fleet/create_ship_waypoint_scan.py
@@ -14,22 +14,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/scan/waypoints".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -37,7 +37,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[CreateShipWaypointScanResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = CreateShipWaypointScanResponse201.from_dict(response.json())
+        response_201 = CreateShipWaypointScanResponse201.update_forward_refs()
+        CreateShipWaypointScanResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -60,7 +61,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateShipWaypointScanResponse201]:
     """Scan Waypoints
 
@@ -79,21 +80,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateShipWaypointScanResponse201]:
     """Scan Waypoints
 
@@ -112,14 +113,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateShipWaypointScanResponse201]:
     """Scan Waypoints
 
@@ -138,19 +139,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateShipWaypointScanResponse201]:
     """Scan Waypoints
 
@@ -170,6 +171,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/create_survey.py
+++ b/spacetraders/api/fleet/create_survey.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/survey".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[CreateSurveyResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = CreateSurveyResponse201.from_dict(response.json())
+        response_201 = CreateSurveyResponse201.update_forward_refs()
+        CreateSurveyResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateSurveyResponse201]:
     """Create Survey
 
@@ -83,21 +84,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateSurveyResponse201]:
     """Create Survey
 
@@ -122,14 +123,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[CreateSurveyResponse201]:
     """Create Survey
 
@@ -154,19 +155,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[CreateSurveyResponse201]:
     """Create Survey
 
@@ -192,6 +193,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/dock_ship.py
+++ b/spacetraders/api/fleet/dock_ship.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/dock".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[DockShipDockShip200Response]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = DockShipDockShip200Response.from_dict(response.json())
+        response_200 = DockShipDockShip200Response.update_forward_refs()
+        DockShipDockShip200Response(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[DockShipDockShip200Response]:
     """Dock Ship
 
@@ -80,21 +81,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[DockShipDockShip200Response]:
     """Dock Ship
 
@@ -116,14 +117,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[DockShipDockShip200Response]:
     """Dock Ship
 
@@ -145,19 +146,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[DockShipDockShip200Response]:
     """Dock Ship
 
@@ -180,6 +181,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/extract_resources.py
+++ b/spacetraders/api/fleet/extract_resources.py
@@ -13,25 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: ExtractResourcesJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/extract".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -40,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[ExtractResourcesResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = ExtractResourcesResponse201.from_dict(response.json())
+        response_201 = ExtractResourcesResponse201.update_forward_refs()
+        ExtractResourcesResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -63,8 +64,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ExtractResourcesJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ExtractResourcesJsonBody,
 ) -> Response[ExtractResourcesResponse201]:
     """Extract Resources
 
@@ -83,25 +84,27 @@ def sync_detailed(
         Response[ExtractResourcesResponse201]
     """
 
+    json_body = ExtractResourcesJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ExtractResourcesJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ExtractResourcesJsonBody,
 ) -> Optional[ExtractResourcesResponse201]:
     """Extract Resources
 
@@ -122,7 +125,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -130,8 +133,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ExtractResourcesJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ExtractResourcesJsonBody,
 ) -> Response[ExtractResourcesResponse201]:
     """Extract Resources
 
@@ -150,23 +153,25 @@ async def asyncio_detailed(
         Response[ExtractResourcesResponse201]
     """
 
+    json_body = ExtractResourcesJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ExtractResourcesJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ExtractResourcesJsonBody,
 ) -> Optional[ExtractResourcesResponse201]:
     """Extract Resources
 
@@ -188,7 +193,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/get_my_ship.py
+++ b/spacetraders/api/fleet/get_my_ship.py
@@ -12,20 +12,20 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
-    url = "{}/my/ships/{shipSymbol}".format(client.base_url, shipSymbol=ship_symbol)
+    url = "{}/my/ships/{shipSymbol}".format(_client.base_url, shipSymbol=ship_symbol)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -33,7 +33,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetMyShipResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetMyShipResponse200.from_dict(response.json())
+        response_200 = GetMyShipResponse200.update_forward_refs()
+        GetMyShipResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -56,7 +57,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMyShipResponse200]:
     """Get Ship
 
@@ -75,21 +76,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMyShipResponse200]:
     """Get Ship
 
@@ -108,14 +109,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMyShipResponse200]:
     """Get Ship
 
@@ -134,19 +135,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMyShipResponse200]:
     """Get Ship
 
@@ -166,6 +167,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/get_my_ship_cargo.py
+++ b/spacetraders/api/fleet/get_my_ship_cargo.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/cargo".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetMyShipCargoResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetMyShipCargoResponse200.from_dict(response.json())
+        response_200 = GetMyShipCargoResponse200.update_forward_refs()
+        GetMyShipCargoResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMyShipCargoResponse200]:
     """Get Ship Cargo
 
@@ -77,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMyShipCargoResponse200]:
     """Get Ship Cargo
 
@@ -110,14 +111,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMyShipCargoResponse200]:
     """Get Ship Cargo
 
@@ -136,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMyShipCargoResponse200]:
     """Get Ship Cargo
 
@@ -168,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/get_my_ships.py
+++ b/spacetraders/api/fleet/get_my_ships.py
@@ -11,14 +11,14 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/my/ships".format(client.base_url)
+    url = "{}/my/ships".format(_client.base_url)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     params: Dict[str, Any] = {}
     params["page"] = page
@@ -32,8 +32,8 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "params": params,
     }
 
@@ -42,7 +42,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetMyShipsResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetMyShipsResponse200.from_dict(response.json())
+        response_200 = GetMyShipsResponse200.update_forward_refs()
+        GetMyShipsResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -64,7 +65,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetMyShipsResponse200]:
@@ -85,22 +86,22 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetMyShipsResponse200]:
@@ -121,7 +122,7 @@ def sync(
     """
 
     return sync_detailed(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     ).parsed
@@ -129,7 +130,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetMyShipsResponse200]:
@@ -150,20 +151,20 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetMyShipsResponse200]:
@@ -185,7 +186,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            client=client,
+            _client=_client,
             page=page,
             limit=limit,
         )

--- a/spacetraders/api/fleet/get_ship_cooldown.py
+++ b/spacetraders/api/fleet/get_ship_cooldown.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/cooldown".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[Union[Any, GetShipCooldownResponse200]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetShipCooldownResponse200.from_dict(response.json())
+        response_200 = GetShipCooldownResponse200.update_forward_refs()
+        GetShipCooldownResponse200(**response.json())
 
         return response_200
     if response.status_code == HTTPStatus.NO_CONTENT:
@@ -61,7 +62,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[Union[Any, GetShipCooldownResponse200]]:
     """Get Ship Cooldown
 
@@ -86,21 +87,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[Union[Any, GetShipCooldownResponse200]]:
     """Get Ship Cooldown
 
@@ -125,14 +126,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[Union[Any, GetShipCooldownResponse200]]:
     """Get Ship Cooldown
 
@@ -157,19 +158,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[Union[Any, GetShipCooldownResponse200]]:
     """Get Ship Cooldown
 
@@ -195,6 +196,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/get_ship_nav.py
+++ b/spacetraders/api/fleet/get_ship_nav.py
@@ -12,20 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
-    url = "{}/my/ships/{shipSymbol}/nav".format(client.base_url, shipSymbol=ship_symbol)
+    url = "{}/my/ships/{shipSymbol}/nav".format(
+        _client.base_url, shipSymbol=ship_symbol
+    )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -33,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetShipNavResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetShipNavResponse200.from_dict(response.json())
+        response_200 = GetShipNavResponse200.update_forward_refs()
+        GetShipNavResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -56,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetShipNavResponse200]:
     """Get Ship Nav
 
@@ -75,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetShipNavResponse200]:
     """Get Ship Nav
 
@@ -108,14 +111,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetShipNavResponse200]:
     """Get Ship Nav
 
@@ -134,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetShipNavResponse200]:
     """Get Ship Nav
 
@@ -166,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/jettison.py
+++ b/spacetraders/api/fleet/jettison.py
@@ -13,25 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: JettisonJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/jettison".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -40,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[JettisonResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = JettisonResponse200.from_dict(response.json())
+        response_200 = JettisonResponse200.update_forward_refs()
+        JettisonResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -63,8 +64,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JettisonJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JettisonJsonBody,
 ) -> Response[JettisonResponse200]:
     """Jettison Cargo
 
@@ -82,25 +83,27 @@ def sync_detailed(
         Response[JettisonResponse200]
     """
 
+    json_body = JettisonJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JettisonJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JettisonJsonBody,
 ) -> Optional[JettisonResponse200]:
     """Jettison Cargo
 
@@ -120,7 +123,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -128,8 +131,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JettisonJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JettisonJsonBody,
 ) -> Response[JettisonResponse200]:
     """Jettison Cargo
 
@@ -147,23 +150,25 @@ async def asyncio_detailed(
         Response[JettisonResponse200]
     """
 
+    json_body = JettisonJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JettisonJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JettisonJsonBody,
 ) -> Optional[JettisonResponse200]:
     """Jettison Cargo
 
@@ -184,7 +189,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/jump_ship.py
+++ b/spacetraders/api/fleet/jump_ship.py
@@ -13,25 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: JumpShipJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/jump".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -40,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[JumpShipResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = JumpShipResponse200.from_dict(response.json())
+        response_200 = JumpShipResponse200.update_forward_refs()
+        JumpShipResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -63,8 +64,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JumpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JumpShipJsonBody,
 ) -> Response[JumpShipResponse200]:
     """Jump Ship
 
@@ -83,25 +84,27 @@ def sync_detailed(
         Response[JumpShipResponse200]
     """
 
+    json_body = JumpShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JumpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JumpShipJsonBody,
 ) -> Optional[JumpShipResponse200]:
     """Jump Ship
 
@@ -122,7 +125,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -130,8 +133,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JumpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JumpShipJsonBody,
 ) -> Response[JumpShipResponse200]:
     """Jump Ship
 
@@ -150,23 +153,25 @@ async def asyncio_detailed(
         Response[JumpShipResponse200]
     """
 
+    json_body = JumpShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: JumpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: JumpShipJsonBody,
 ) -> Optional[JumpShipResponse200]:
     """Jump Ship
 
@@ -188,7 +193,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/navigate_ship.py
+++ b/spacetraders/api/fleet/navigate_ship.py
@@ -13,25 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: NavigateShipJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/navigate".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -40,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[NavigateShipResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = NavigateShipResponse200.from_dict(response.json())
+        response_200 = NavigateShipResponse200.update_forward_refs()
+        NavigateShipResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -63,8 +64,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: NavigateShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: NavigateShipJsonBody,
 ) -> Response[NavigateShipResponse200]:
     """Navigate Ship
 
@@ -89,25 +90,27 @@ def sync_detailed(
         Response[NavigateShipResponse200]
     """
 
+    json_body = NavigateShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: NavigateShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: NavigateShipJsonBody,
 ) -> Optional[NavigateShipResponse200]:
     """Navigate Ship
 
@@ -134,7 +137,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -142,8 +145,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: NavigateShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: NavigateShipJsonBody,
 ) -> Response[NavigateShipResponse200]:
     """Navigate Ship
 
@@ -168,23 +171,25 @@ async def asyncio_detailed(
         Response[NavigateShipResponse200]
     """
 
+    json_body = NavigateShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: NavigateShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: NavigateShipJsonBody,
 ) -> Optional[NavigateShipResponse200]:
     """Navigate Ship
 
@@ -212,7 +217,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/orbit_ship.py
+++ b/spacetraders/api/fleet/orbit_ship.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/orbit".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[OrbitShipOrbitShip200Response]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = OrbitShipOrbitShip200Response.from_dict(response.json())
+        response_200 = OrbitShipOrbitShip200Response.update_forward_refs()
+        OrbitShipOrbitShip200Response(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[OrbitShipOrbitShip200Response]:
     """Orbit Ship
 
@@ -80,21 +81,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[OrbitShipOrbitShip200Response]:
     """Orbit Ship
 
@@ -116,14 +117,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[OrbitShipOrbitShip200Response]:
     """Orbit Ship
 
@@ -145,19 +146,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[OrbitShipOrbitShip200Response]:
     """Orbit Ship
 
@@ -180,6 +181,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/patch_ship_nav.py
+++ b/spacetraders/api/fleet/patch_ship_nav.py
@@ -13,23 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: PatchShipNavJsonBody,
 ) -> Dict[str, Any]:
-    url = "{}/my/ships/{shipSymbol}/nav".format(client.base_url, shipSymbol=ship_symbol)
+    url = "{}/my/ships/{shipSymbol}/nav".format(
+        _client.base_url, shipSymbol=ship_symbol
+    )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "patch",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -38,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[PatchShipNavResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = PatchShipNavResponse200.from_dict(response.json())
+        response_200 = PatchShipNavResponse200.update_forward_refs()
+        PatchShipNavResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -61,8 +64,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PatchShipNavJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PatchShipNavJsonBody,
 ) -> Response[PatchShipNavResponse200]:
     """Patch Ship Nav
 
@@ -80,25 +83,27 @@ def sync_detailed(
         Response[PatchShipNavResponse200]
     """
 
+    json_body = PatchShipNavJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PatchShipNavJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PatchShipNavJsonBody,
 ) -> Optional[PatchShipNavResponse200]:
     """Patch Ship Nav
 
@@ -118,7 +123,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -126,8 +131,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PatchShipNavJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PatchShipNavJsonBody,
 ) -> Response[PatchShipNavResponse200]:
     """Patch Ship Nav
 
@@ -145,23 +150,25 @@ async def asyncio_detailed(
         Response[PatchShipNavResponse200]
     """
 
+    json_body = PatchShipNavJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PatchShipNavJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PatchShipNavJsonBody,
 ) -> Optional[PatchShipNavResponse200]:
     """Patch Ship Nav
 
@@ -182,7 +189,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/purchase_cargo.py
+++ b/spacetraders/api/fleet/purchase_cargo.py
@@ -17,25 +17,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: PurchaseCargoPurchaseCargoRequest,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/purchase".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -44,7 +44,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[PurchaseCargoPurchaseCargo201Response]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = PurchaseCargoPurchaseCargo201Response.from_dict(response.json())
+        response_201 = PurchaseCargoPurchaseCargo201Response.update_forward_refs()
+        PurchaseCargoPurchaseCargo201Response(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -67,8 +68,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseCargoPurchaseCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseCargoPurchaseCargoRequest,
 ) -> Response[PurchaseCargoPurchaseCargo201Response]:
     """Purchase Cargo
 
@@ -86,25 +87,27 @@ def sync_detailed(
         Response[PurchaseCargoPurchaseCargo201Response]
     """
 
+    json_body = PurchaseCargoPurchaseCargoRequest(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseCargoPurchaseCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseCargoPurchaseCargoRequest,
 ) -> Optional[PurchaseCargoPurchaseCargo201Response]:
     """Purchase Cargo
 
@@ -124,7 +127,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -132,8 +135,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseCargoPurchaseCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseCargoPurchaseCargoRequest,
 ) -> Response[PurchaseCargoPurchaseCargo201Response]:
     """Purchase Cargo
 
@@ -151,23 +154,25 @@ async def asyncio_detailed(
         Response[PurchaseCargoPurchaseCargo201Response]
     """
 
+    json_body = PurchaseCargoPurchaseCargoRequest(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseCargoPurchaseCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseCargoPurchaseCargoRequest,
 ) -> Optional[PurchaseCargoPurchaseCargo201Response]:
     """Purchase Cargo
 
@@ -188,7 +193,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/purchase_ship.py
+++ b/spacetraders/api/fleet/purchase_ship.py
@@ -12,23 +12,23 @@ from ...types import UNSET, Response
 
 def _get_kwargs(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: PurchaseShipJsonBody,
 ) -> Dict[str, Any]:
-    url = "{}/my/ships".format(client.base_url)
+    url = "{}/my/ships".format(_client.base_url)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -37,7 +37,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[PurchaseShipResponse201]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = PurchaseShipResponse201.from_dict(response.json())
+        response_201 = PurchaseShipResponse201.update_forward_refs()
+        PurchaseShipResponse201(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -59,8 +60,8 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseShipJsonBody,
 ) -> Response[PurchaseShipResponse201]:
     """Purchase Ship
 
@@ -77,23 +78,25 @@ def sync_detailed(
         Response[PurchaseShipResponse201]
     """
 
+    json_body = PurchaseShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseShipJsonBody,
 ) -> Optional[PurchaseShipResponse201]:
     """Purchase Ship
 
@@ -111,15 +114,15 @@ def sync(
     """
 
     return sync_detailed(
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseShipJsonBody,
 ) -> Response[PurchaseShipResponse201]:
     """Purchase Ship
 
@@ -136,21 +139,23 @@ async def asyncio_detailed(
         Response[PurchaseShipResponse201]
     """
 
+    json_body = PurchaseShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
-    json_body: PurchaseShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: PurchaseShipJsonBody,
 ) -> Optional[PurchaseShipResponse201]:
     """Purchase Ship
 
@@ -169,7 +174,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/refuel_ship.py
+++ b/spacetraders/api/fleet/refuel_ship.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/refuel".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[RefuelShipResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = RefuelShipResponse200.from_dict(response.json())
+        response_200 = RefuelShipResponse200.update_forward_refs()
+        RefuelShipResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[RefuelShipResponse200]:
     """Refuel Ship
 
@@ -77,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[RefuelShipResponse200]:
     """Refuel Ship
 
@@ -110,14 +111,14 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[RefuelShipResponse200]:
     """Refuel Ship
 
@@ -136,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[RefuelShipResponse200]:
     """Refuel Ship
 
@@ -168,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/fleet/sell_cargo.py
+++ b/spacetraders/api/fleet/sell_cargo.py
@@ -13,25 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: SellCargoSellCargoRequest,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/sell".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -40,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[SellCargoSellCargo201Response]:
     if response.status_code == HTTPStatus.CREATED:
-        response_201 = SellCargoSellCargo201Response.from_dict(response.json())
+        response_201 = SellCargoSellCargo201Response.update_forward_refs()
+        SellCargoSellCargo201Response(**response.json())
 
         return response_201
     if client.raise_on_unexpected_status:
@@ -63,8 +64,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: SellCargoSellCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: SellCargoSellCargoRequest,
 ) -> Response[SellCargoSellCargo201Response]:
     """Sell Cargo
 
@@ -82,25 +83,27 @@ def sync_detailed(
         Response[SellCargoSellCargo201Response]
     """
 
+    json_body = SellCargoSellCargoRequest(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: SellCargoSellCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: SellCargoSellCargoRequest,
 ) -> Optional[SellCargoSellCargo201Response]:
     """Sell Cargo
 
@@ -120,7 +123,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -128,8 +131,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: SellCargoSellCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: SellCargoSellCargoRequest,
 ) -> Response[SellCargoSellCargo201Response]:
     """Sell Cargo
 
@@ -147,23 +150,25 @@ async def asyncio_detailed(
         Response[SellCargoSellCargo201Response]
     """
 
+    json_body = SellCargoSellCargoRequest(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: SellCargoSellCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: SellCargoSellCargoRequest,
 ) -> Optional[SellCargoSellCargo201Response]:
     """Sell Cargo
 
@@ -184,7 +189,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/ship_refine.py
+++ b/spacetraders/api/fleet/ship_refine.py
@@ -15,25 +15,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: ShipRefineJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/refine".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -42,7 +42,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[ShipRefineShipRefine200Response]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = ShipRefineShipRefine200Response.from_dict(response.json())
+        response_200 = ShipRefineShipRefine200Response.update_forward_refs()
+        ShipRefineShipRefine200Response(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -65,8 +66,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ShipRefineJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ShipRefineJsonBody,
 ) -> Response[ShipRefineShipRefine200Response]:
     """Ship Refine
 
@@ -85,25 +86,27 @@ def sync_detailed(
         Response[ShipRefineShipRefine200Response]
     """
 
+    json_body = ShipRefineJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ShipRefineJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ShipRefineJsonBody,
 ) -> Optional[ShipRefineShipRefine200Response]:
     """Ship Refine
 
@@ -124,7 +127,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -132,8 +135,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ShipRefineJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ShipRefineJsonBody,
 ) -> Response[ShipRefineShipRefine200Response]:
     """Ship Refine
 
@@ -152,23 +155,25 @@ async def asyncio_detailed(
         Response[ShipRefineShipRefine200Response]
     """
 
+    json_body = ShipRefineJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: ShipRefineJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: ShipRefineJsonBody,
 ) -> Optional[ShipRefineShipRefine200Response]:
     """Ship Refine
 
@@ -190,7 +195,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/transfer_cargo.py
+++ b/spacetraders/api/fleet/transfer_cargo.py
@@ -17,25 +17,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: TransferCargoTransferCargoRequest,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/transfer".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -44,7 +44,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[TransferCargoTransferCargo200Response]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = TransferCargoTransferCargo200Response.from_dict(response.json())
+        response_200 = TransferCargoTransferCargo200Response.update_forward_refs()
+        TransferCargoTransferCargo200Response(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -67,8 +68,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: TransferCargoTransferCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: TransferCargoTransferCargoRequest,
 ) -> Response[TransferCargoTransferCargo200Response]:
     """Transfer Cargo
 
@@ -86,25 +87,27 @@ def sync_detailed(
         Response[TransferCargoTransferCargo200Response]
     """
 
+    json_body = TransferCargoTransferCargoRequest(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: TransferCargoTransferCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: TransferCargoTransferCargoRequest,
 ) -> Optional[TransferCargoTransferCargo200Response]:
     """Transfer Cargo
 
@@ -124,7 +127,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -132,8 +135,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: TransferCargoTransferCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: TransferCargoTransferCargoRequest,
 ) -> Response[TransferCargoTransferCargo200Response]:
     """Transfer Cargo
 
@@ -151,23 +154,25 @@ async def asyncio_detailed(
         Response[TransferCargoTransferCargo200Response]
     """
 
+    json_body = TransferCargoTransferCargoRequest(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: TransferCargoTransferCargoRequest,
+    _client: AuthenticatedClient,
+    **json_body: TransferCargoTransferCargoRequest,
 ) -> Optional[TransferCargoTransferCargo200Response]:
     """Transfer Cargo
 
@@ -188,7 +193,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/fleet/warp_ship.py
+++ b/spacetraders/api/fleet/warp_ship.py
@@ -13,25 +13,25 @@ from ...types import UNSET, Response
 def _get_kwargs(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     json_body: WarpShipJsonBody,
 ) -> Dict[str, Any]:
     url = "{}/my/ships/{shipSymbol}/warp".format(
-        client.base_url, shipSymbol=ship_symbol
+        _client.base_url, shipSymbol=ship_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
-    json_json_body = json_body.to_dict()
+    json_json_body = json_body.dict()
 
     return {
         "method": "post",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "json": json_json_body,
     }
 
@@ -40,7 +40,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[WarpShipResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = WarpShipResponse200.from_dict(response.json())
+        response_200 = WarpShipResponse200.update_forward_refs()
+        WarpShipResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -63,8 +64,8 @@ def _build_response(
 def sync_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: WarpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: WarpShipJsonBody,
 ) -> Response[WarpShipResponse200]:
     """Warp Ship
 
@@ -86,25 +87,27 @@ def sync_detailed(
         Response[WarpShipResponse200]
     """
 
+    json_body = WarpShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: WarpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: WarpShipJsonBody,
 ) -> Optional[WarpShipResponse200]:
     """Warp Ship
 
@@ -128,7 +131,7 @@ def sync(
 
     return sync_detailed(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     ).parsed
 
@@ -136,8 +139,8 @@ def sync(
 async def asyncio_detailed(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: WarpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: WarpShipJsonBody,
 ) -> Response[WarpShipResponse200]:
     """Warp Ship
 
@@ -159,23 +162,25 @@ async def asyncio_detailed(
         Response[WarpShipResponse200]
     """
 
+    json_body = WarpShipJsonBody(**json_body)
+
     kwargs = _get_kwargs(
         ship_symbol=ship_symbol,
-        client=client,
+        _client=_client,
         json_body=json_body,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     ship_symbol: str,
     *,
-    client: AuthenticatedClient,
-    json_body: WarpShipJsonBody,
+    _client: AuthenticatedClient,
+    **json_body: WarpShipJsonBody,
 ) -> Optional[WarpShipResponse200]:
     """Warp Ship
 
@@ -200,7 +205,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             ship_symbol=ship_symbol,
-            client=client,
+            _client=_client,
             json_body=json_body,
         )
     ).parsed

--- a/spacetraders/api/systems/get_jump_gate.py
+++ b/spacetraders/api/systems/get_jump_gate.py
@@ -13,22 +13,22 @@ def _get_kwargs(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/systems/{systemSymbol}/waypoints/{waypointSymbol}/jump-gate".format(
-        client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
+        _client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -36,7 +36,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetJumpGateResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetJumpGateResponse200.from_dict(response.json())
+        response_200 = GetJumpGateResponse200.update_forward_refs()
+        GetJumpGateResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -60,7 +61,7 @@ def sync_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetJumpGateResponse200]:
     """Get Jump Gate
 
@@ -81,22 +82,22 @@ def sync_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetJumpGateResponse200]:
     """Get Jump Gate
 
@@ -117,7 +118,7 @@ def sync(
     return sync_detailed(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
@@ -125,7 +126,7 @@ async def asyncio_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetJumpGateResponse200]:
     """Get Jump Gate
 
@@ -146,20 +147,20 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetJumpGateResponse200]:
     """Get Jump Gate
 
@@ -181,6 +182,6 @@ async def asyncio(
         await asyncio_detailed(
             system_symbol=system_symbol,
             waypoint_symbol=waypoint_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/systems/get_market.py
+++ b/spacetraders/api/systems/get_market.py
@@ -13,22 +13,22 @@ def _get_kwargs(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/systems/{systemSymbol}/waypoints/{waypointSymbol}/market".format(
-        client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
+        _client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -36,7 +36,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetMarketResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetMarketResponse200.from_dict(response.json())
+        response_200 = GetMarketResponse200.update_forward_refs()
+        GetMarketResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -60,7 +61,7 @@ def sync_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMarketResponse200]:
     """Get Market
 
@@ -83,22 +84,22 @@ def sync_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMarketResponse200]:
     """Get Market
 
@@ -121,7 +122,7 @@ def sync(
     return sync_detailed(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
@@ -129,7 +130,7 @@ async def asyncio_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetMarketResponse200]:
     """Get Market
 
@@ -152,20 +153,20 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetMarketResponse200]:
     """Get Market
 
@@ -189,6 +190,6 @@ async def asyncio(
         await asyncio_detailed(
             system_symbol=system_symbol,
             waypoint_symbol=waypoint_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/systems/get_shipyard.py
+++ b/spacetraders/api/systems/get_shipyard.py
@@ -13,22 +13,22 @@ def _get_kwargs(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/systems/{systemSymbol}/waypoints/{waypointSymbol}/shipyard".format(
-        client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
+        _client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -36,7 +36,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetShipyardResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetShipyardResponse200.from_dict(response.json())
+        response_200 = GetShipyardResponse200.update_forward_refs()
+        GetShipyardResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -60,7 +61,7 @@ def sync_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetShipyardResponse200]:
     """Get Shipyard
 
@@ -81,22 +82,22 @@ def sync_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetShipyardResponse200]:
     """Get Shipyard
 
@@ -117,7 +118,7 @@ def sync(
     return sync_detailed(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
@@ -125,7 +126,7 @@ async def asyncio_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetShipyardResponse200]:
     """Get Shipyard
 
@@ -146,20 +147,20 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetShipyardResponse200]:
     """Get Shipyard
 
@@ -181,6 +182,6 @@ async def asyncio(
         await asyncio_detailed(
             system_symbol=system_symbol,
             waypoint_symbol=waypoint_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/systems/get_system.py
+++ b/spacetraders/api/systems/get_system.py
@@ -12,22 +12,22 @@ from ...types import UNSET, Response
 def _get_kwargs(
     system_symbol: str = "X1-OE",
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/systems/{systemSymbol}".format(
-        client.base_url, systemSymbol=system_symbol
+        _client.base_url, systemSymbol=system_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -35,7 +35,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetSystemResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetSystemResponse200.from_dict(response.json())
+        response_200 = GetSystemResponse200.update_forward_refs()
+        GetSystemResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -58,7 +59,7 @@ def _build_response(
 def sync_detailed(
     system_symbol: str = "X1-OE",
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetSystemResponse200]:
     """Get System
 
@@ -77,21 +78,21 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     system_symbol: str = "X1-OE",
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetSystemResponse200]:
     """Get System
 
@@ -110,14 +111,14 @@ def sync(
 
     return sync_detailed(
         system_symbol=system_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
 async def asyncio_detailed(
     system_symbol: str = "X1-OE",
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetSystemResponse200]:
     """Get System
 
@@ -136,19 +137,19 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     system_symbol: str = "X1-OE",
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetSystemResponse200]:
     """Get System
 
@@ -168,6 +169,6 @@ async def asyncio(
     return (
         await asyncio_detailed(
             system_symbol=system_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/api/systems/get_system_waypoints.py
+++ b/spacetraders/api/systems/get_system_waypoints.py
@@ -12,16 +12,16 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     system_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Dict[str, Any]:
     url = "{}/systems/{systemSymbol}/waypoints".format(
-        client.base_url, systemSymbol=system_symbol
+        _client.base_url, systemSymbol=system_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     params: Dict[str, Any] = {}
     params["page"] = page
@@ -35,8 +35,8 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "params": params,
     }
 
@@ -45,7 +45,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetSystemWaypointsResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetSystemWaypointsResponse200.from_dict(response.json())
+        response_200 = GetSystemWaypointsResponse200.update_forward_refs()
+        GetSystemWaypointsResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -68,7 +69,7 @@ def _build_response(
 def sync_detailed(
     system_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetSystemWaypointsResponse200]:
@@ -92,23 +93,23 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     system_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetSystemWaypointsResponse200]:
@@ -132,7 +133,7 @@ def sync(
 
     return sync_detailed(
         system_symbol=system_symbol,
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     ).parsed
@@ -141,7 +142,7 @@ def sync(
 async def asyncio_detailed(
     system_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetSystemWaypointsResponse200]:
@@ -165,21 +166,21 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     system_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetSystemWaypointsResponse200]:
@@ -204,7 +205,7 @@ async def asyncio(
     return (
         await asyncio_detailed(
             system_symbol=system_symbol,
-            client=client,
+            _client=_client,
             page=page,
             limit=limit,
         )

--- a/spacetraders/api/systems/get_systems.py
+++ b/spacetraders/api/systems/get_systems.py
@@ -11,14 +11,14 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/systems".format(client.base_url)
+    url = "{}/systems".format(_client.base_url)
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     params: Dict[str, Any] = {}
     params["page"] = page
@@ -32,8 +32,8 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
         "params": params,
     }
 
@@ -42,7 +42,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetSystemsResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetSystemsResponse200.from_dict(response.json())
+        response_200 = GetSystemsResponse200.update_forward_refs()
+        GetSystemsResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -64,7 +65,7 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetSystemsResponse200]:
@@ -85,22 +86,22 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetSystemsResponse200]:
@@ -121,7 +122,7 @@ def sync(
     """
 
     return sync_detailed(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     ).parsed
@@ -129,7 +130,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Response[GetSystemsResponse200]:
@@ -150,20 +151,20 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        client=client,
+        _client=_client,
         page=page,
         limit=limit,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
     page: Union[Unset, None, int] = UNSET,
     limit: Union[Unset, None, int] = UNSET,
 ) -> Optional[GetSystemsResponse200]:
@@ -185,7 +186,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            client=client,
+            _client=_client,
             page=page,
             limit=limit,
         )

--- a/spacetraders/api/systems/get_waypoint.py
+++ b/spacetraders/api/systems/get_waypoint.py
@@ -13,22 +13,22 @@ def _get_kwargs(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Dict[str, Any]:
     url = "{}/systems/{systemSymbol}/waypoints/{waypointSymbol}".format(
-        client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
+        _client.base_url, systemSymbol=system_symbol, waypointSymbol=waypoint_symbol
     )
 
-    headers: Dict[str, str] = client.get_headers()
-    cookies: Dict[str, Any] = client.get_cookies()
+    headers: Dict[str, str] = _client.get_headers()
+    cookies: Dict[str, Any] = _client.get_cookies()
 
     return {
         "method": "get",
         "url": url,
         "headers": headers,
         "cookies": cookies,
-        "timeout": client.get_timeout(),
-        "follow_redirects": client.follow_redirects,
+        "timeout": _client.get_timeout(),
+        "follow_redirects": _client.follow_redirects,
     }
 
 
@@ -36,7 +36,8 @@ def _parse_response(
     *, client: Client, response: httpx.Response
 ) -> Optional[GetWaypointResponse200]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = GetWaypointResponse200.from_dict(response.json())
+        response_200 = GetWaypointResponse200.update_forward_refs()
+        GetWaypointResponse200(**response.json())
 
         return response_200
     if client.raise_on_unexpected_status:
@@ -60,7 +61,7 @@ def sync_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetWaypointResponse200]:
     """Get Waypoint
 
@@ -81,22 +82,22 @@ def sync_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
     response = httpx.request(
-        verify=client.verify_ssl,
+        verify=_client.verify_ssl,
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 def sync(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetWaypointResponse200]:
     """Get Waypoint
 
@@ -117,7 +118,7 @@ def sync(
     return sync_detailed(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     ).parsed
 
 
@@ -125,7 +126,7 @@ async def asyncio_detailed(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Response[GetWaypointResponse200]:
     """Get Waypoint
 
@@ -146,20 +147,20 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         system_symbol=system_symbol,
         waypoint_symbol=waypoint_symbol,
-        client=client,
+        _client=_client,
     )
 
-    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
-        response = await _client.request(**kwargs)
+    async with httpx.AsyncClient(verify=_client.verify_ssl) as c:
+        response = await c.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(client=_client, response=response)
 
 
 async def asyncio(
     system_symbol: str,
     waypoint_symbol: str,
     *,
-    client: AuthenticatedClient,
+    _client: AuthenticatedClient,
 ) -> Optional[GetWaypointResponse200]:
     """Get Waypoint
 
@@ -181,6 +182,6 @@ async def asyncio(
         await asyncio_detailed(
             system_symbol=system_symbol,
             waypoint_symbol=waypoint_symbol,
-            client=client,
+            _client=_client,
         )
     ).parsed

--- a/spacetraders/client.py
+++ b/spacetraders/client.py
@@ -23,7 +23,7 @@ class APIStub:
         if not hasattr(imp, self._exec_mode):
             return APIStub(client=self._client, mod=imp, exec=self._exec_mode)
 
-        return partial(getattr(imp, self._exec_mode), client=self._client)
+        return partial(getattr(imp, self._exec_mode), _client=self._client)
 
 
 @attr.s(auto_attribs=True)

--- a/spacetraders/models/accept_contract_response_200.py
+++ b/spacetraders/models/accept_contract_response_200.py
@@ -13,58 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.accept_contract_response_200_data import AcceptContractResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.accept_contract_response_200_data import AcceptContractResponse200Data
-
 
 T = TypeVar("T", bound="AcceptContractResponse200")
 
 
-@attr.s(auto_attribs=True)
-class AcceptContractResponse200:
+class AcceptContractResponse200(BaseModel):
     """
     Attributes:
         data (AcceptContractResponse200Data):
     """
 
-    data: "AcceptContractResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "AcceptContractResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.accept_contract_response_200_data import (
-            AcceptContractResponse200Data,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.accept_contract_response_200_data import (
-            AcceptContractResponse200Data,
-        )
-
-        d = src_dict.copy()
-        data = AcceptContractResponse200Data.from_dict(d.pop("data"))
-
-        accept_contract_response_200 = cls(
-            data=data,
-        )
-
-        accept_contract_response_200.additional_properties = d
-        return accept_contract_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/accept_contract_response_200_data.py
+++ b/spacetraders/models/accept_contract_response_200_data.py
@@ -13,65 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
+from ..models.contract import Contract
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-    from ..models.contract import Contract
-
 
 T = TypeVar("T", bound="AcceptContractResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class AcceptContractResponse200Data:
+class AcceptContractResponse200Data(BaseModel):
     """
     Attributes:
         agent (Agent):
         contract (Contract):
     """
 
-    agent: "Agent"
-    contract: "Contract"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    agent: "Agent" = Field(alias="agent")
+    contract: "Contract" = Field(alias="contract")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-        from ..models.contract import Contract
-
-        agent = self.agent.to_dict()
-
-        contract = self.contract.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "agent": agent,
-                "contract": contract,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-        from ..models.contract import Contract
-
-        d = src_dict.copy()
-        agent = Agent.from_dict(d.pop("agent"))
-
-        contract = Contract.from_dict(d.pop("contract"))
-
-        accept_contract_response_200_data = cls(
-            agent=agent,
-            contract=contract,
-        )
-
-        accept_contract_response_200_data.additional_properties = d
-        return accept_contract_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/agent.py
+++ b/spacetraders/models/agent.py
@@ -12,14 +12,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="Agent")
 
 
-@attr.s(auto_attribs=True)
-class Agent:
+class Agent(BaseModel):
     """
     Attributes:
         account_id (str):
@@ -29,51 +29,14 @@ class Agent:
             overdrawn.
     """
 
-    account_id: str
-    symbol: str
-    headquarters: str
-    credits_: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    account_id: str = Field(alias="accountId")
+    symbol: str = Field(alias="symbol")
+    headquarters: str = Field(alias="headquarters")
+    credits_: int = Field(alias="credits")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        account_id = self.account_id
-        symbol = self.symbol
-        headquarters = self.headquarters
-        credits_ = self.credits_
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "accountId": account_id,
-                "symbol": symbol,
-                "headquarters": headquarters,
-                "credits": credits_,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        account_id = d.pop("accountId")
-
-        symbol = d.pop("symbol")
-
-        headquarters = d.pop("headquarters")
-
-        credits_ = d.pop("credits")
-
-        agent = cls(
-            account_id=account_id,
-            symbol=symbol,
-            headquarters=headquarters,
-            credits_=credits_,
-        )
-
-        agent.additional_properties = d
-        return agent
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/chart.py
+++ b/spacetraders/models/chart.py
@@ -16,14 +16,14 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="Chart")
 
 
-@attr.s(auto_attribs=True)
-class Chart:
+class Chart(BaseModel):
     """The chart of a system or waypoint, which makes the location visible to other agents.
 
     Attributes:
@@ -35,49 +35,10 @@ class Chart:
     waypoint_symbol: Union[Unset, str] = UNSET
     submitted_by: Union[Unset, str] = UNSET
     submitted_on: Union[Unset, datetime.datetime] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        waypoint_symbol = self.waypoint_symbol
-        submitted_by = self.submitted_by
-        submitted_on: Union[Unset, str] = UNSET
-        if not isinstance(self.submitted_on, Unset):
-            submitted_on = self.submitted_on.isoformat()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if waypoint_symbol is not UNSET:
-            field_dict["waypointSymbol"] = waypoint_symbol
-        if submitted_by is not UNSET:
-            field_dict["submittedBy"] = submitted_by
-        if submitted_on is not UNSET:
-            field_dict["submittedOn"] = submitted_on
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        waypoint_symbol = d.pop("waypointSymbol", UNSET)
-
-        submitted_by = d.pop("submittedBy", UNSET)
-
-        _submitted_on = d.pop("submittedOn", UNSET)
-        submitted_on: Union[Unset, datetime.datetime]
-        if isinstance(_submitted_on, Unset):
-            submitted_on = UNSET
-        else:
-            submitted_on = isoparse(_submitted_on)
-
-        chart = cls(
-            waypoint_symbol=waypoint_symbol,
-            submitted_by=submitted_by,
-            submitted_on=submitted_on,
-        )
-
-        chart.additional_properties = d
-        return chart
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/connected_system.py
+++ b/spacetraders/models/connected_system.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.system_type import SystemType
 from ..types import UNSET, Unset
@@ -20,8 +21,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="ConnectedSystem")
 
 
-@attr.s(auto_attribs=True)
-class ConnectedSystem:
+class ConnectedSystem(BaseModel):
     """
     Attributes:
         symbol (str):
@@ -33,71 +33,17 @@ class ConnectedSystem:
         faction_symbol (Union[Unset, str]): The symbol of the faction that owns the connected jump gate in the system.
     """
 
-    symbol: str
-    sector_symbol: str
-    type: SystemType
-    x: int
-    y: int
-    distance: int
+    symbol: str = Field(alias="symbol")
+    sector_symbol: str = Field(alias="sectorSymbol")
+    type: SystemType = Field(alias="type")
+    x: int = Field(alias="x")
+    y: int = Field(alias="y")
+    distance: int = Field(alias="distance")
     faction_symbol: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        sector_symbol = self.sector_symbol
-        type = self.type.value
-
-        x = self.x
-        y = self.y
-        distance = self.distance
-        faction_symbol = self.faction_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "sectorSymbol": sector_symbol,
-                "type": type,
-                "x": x,
-                "y": y,
-                "distance": distance,
-            }
-        )
-        if faction_symbol is not UNSET:
-            field_dict["factionSymbol"] = faction_symbol
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        sector_symbol = d.pop("sectorSymbol")
-
-        type = SystemType(d.pop("type"))
-
-        x = d.pop("x")
-
-        y = d.pop("y")
-
-        distance = d.pop("distance")
-
-        faction_symbol = d.pop("factionSymbol", UNSET)
-
-        connected_system = cls(
-            symbol=symbol,
-            sector_symbol=sector_symbol,
-            type=type,
-            x=x,
-            y=y,
-            distance=distance,
-            faction_symbol=faction_symbol,
-        )
-
-        connected_system.additional_properties = d
-        return connected_system
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/contract.py
+++ b/spacetraders/models/contract.py
@@ -15,19 +15,16 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
+from ..models.contract_terms import ContractTerms
 from ..models.contract_type import ContractType
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.contract_terms import ContractTerms
-
 
 T = TypeVar("T", bound="Contract")
 
 
-@attr.s(auto_attribs=True)
-class Contract:
+class Contract(BaseModel):
     """
     Attributes:
         id (str):
@@ -39,75 +36,17 @@ class Contract:
         expiration (datetime.datetime): The time at which the contract expires
     """
 
-    id: str
-    faction_symbol: str
-    type: ContractType
-    terms: "ContractTerms"
-    expiration: datetime.datetime
+    id: str = Field(alias="id")
+    faction_symbol: str = Field(alias="factionSymbol")
+    type: ContractType = Field(alias="type")
+    terms: "ContractTerms" = Field(alias="terms")
+    expiration: datetime.datetime = Field(alias="expiration")
     accepted: bool = False
     fulfilled: bool = False
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.contract_terms import ContractTerms
-
-        id = self.id
-        faction_symbol = self.faction_symbol
-        type = self.type.value
-
-        terms = self.terms.to_dict()
-
-        accepted = self.accepted
-        fulfilled = self.fulfilled
-        expiration = self.expiration.isoformat()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "id": id,
-                "factionSymbol": faction_symbol,
-                "type": type,
-                "terms": terms,
-                "accepted": accepted,
-                "fulfilled": fulfilled,
-                "expiration": expiration,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.contract_terms import ContractTerms
-
-        d = src_dict.copy()
-        id = d.pop("id")
-
-        faction_symbol = d.pop("factionSymbol")
-
-        type = ContractType(d.pop("type"))
-
-        terms = ContractTerms.from_dict(d.pop("terms"))
-
-        accepted = d.pop("accepted")
-
-        fulfilled = d.pop("fulfilled")
-
-        expiration = isoparse(d.pop("expiration"))
-
-        contract = cls(
-            id=id,
-            faction_symbol=faction_symbol,
-            type=type,
-            terms=terms,
-            accepted=accepted,
-            fulfilled=fulfilled,
-            expiration=expiration,
-        )
-
-        contract.additional_properties = d
-        return contract
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/contract_deliver_good.py
+++ b/spacetraders/models/contract_deliver_good.py
@@ -12,14 +12,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ContractDeliverGood")
 
 
-@attr.s(auto_attribs=True)
-class ContractDeliverGood:
+class ContractDeliverGood(BaseModel):
     """The details of a delivery contract. Includes the type of good, units needed, and the destination.
 
     Attributes:
@@ -29,51 +29,14 @@ class ContractDeliverGood:
         units_fulfilled (int): The number of units fulfilled on this contract.
     """
 
-    trade_symbol: str
-    destination_symbol: str
-    units_required: int
-    units_fulfilled: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    trade_symbol: str = Field(alias="tradeSymbol")
+    destination_symbol: str = Field(alias="destinationSymbol")
+    units_required: int = Field(alias="unitsRequired")
+    units_fulfilled: int = Field(alias="unitsFulfilled")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        trade_symbol = self.trade_symbol
-        destination_symbol = self.destination_symbol
-        units_required = self.units_required
-        units_fulfilled = self.units_fulfilled
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "tradeSymbol": trade_symbol,
-                "destinationSymbol": destination_symbol,
-                "unitsRequired": units_required,
-                "unitsFulfilled": units_fulfilled,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        trade_symbol = d.pop("tradeSymbol")
-
-        destination_symbol = d.pop("destinationSymbol")
-
-        units_required = d.pop("unitsRequired")
-
-        units_fulfilled = d.pop("unitsFulfilled")
-
-        contract_deliver_good = cls(
-            trade_symbol=trade_symbol,
-            destination_symbol=destination_symbol,
-            units_required=units_required,
-            units_fulfilled=units_fulfilled,
-        )
-
-        contract_deliver_good.additional_properties = d
-        return contract_deliver_good
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/contract_payment.py
+++ b/spacetraders/models/contract_payment.py
@@ -12,53 +12,26 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ContractPayment")
 
 
-@attr.s(auto_attribs=True)
-class ContractPayment:
+class ContractPayment(BaseModel):
     """
     Attributes:
         on_accepted (int): The amount of credits received up front for accepting the contract.
         on_fulfilled (int): The amount of credits received when the contract is fulfilled.
     """
 
-    on_accepted: int
-    on_fulfilled: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    on_accepted: int = Field(alias="onAccepted")
+    on_fulfilled: int = Field(alias="onFulfilled")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        on_accepted = self.on_accepted
-        on_fulfilled = self.on_fulfilled
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "onAccepted": on_accepted,
-                "onFulfilled": on_fulfilled,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        on_accepted = d.pop("onAccepted")
-
-        on_fulfilled = d.pop("onFulfilled")
-
-        contract_payment = cls(
-            on_accepted=on_accepted,
-            on_fulfilled=on_fulfilled,
-        )
-
-        contract_payment.additional_properties = d
-        return contract_payment
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/contract_terms.py
+++ b/spacetraders/models/contract_terms.py
@@ -16,19 +16,16 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
+from ..models.contract_deliver_good import ContractDeliverGood
+from ..models.contract_payment import ContractPayment
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.contract_deliver_good import ContractDeliverGood
-    from ..models.contract_payment import ContractPayment
-
 
 T = TypeVar("T", bound="ContractTerms")
 
 
-@attr.s(auto_attribs=True)
-class ContractTerms:
+class ContractTerms(BaseModel):
     """
     Attributes:
         deadline (datetime.datetime): The deadline for the contract.
@@ -36,65 +33,13 @@ class ContractTerms:
         deliver (Union[Unset, List['ContractDeliverGood']]):
     """
 
-    deadline: datetime.datetime
-    payment: "ContractPayment"
+    deadline: datetime.datetime = Field(alias="deadline")
+    payment: "ContractPayment" = Field(alias="payment")
     deliver: Union[Unset, List["ContractDeliverGood"]] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.contract_deliver_good import ContractDeliverGood
-        from ..models.contract_payment import ContractPayment
-
-        deadline = self.deadline.isoformat()
-
-        payment = self.payment.to_dict()
-
-        deliver: Union[Unset, List[Dict[str, Any]]] = UNSET
-        if not isinstance(self.deliver, Unset):
-            deliver = []
-            for deliver_item_data in self.deliver:
-                deliver_item = deliver_item_data.to_dict()
-
-                deliver.append(deliver_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "deadline": deadline,
-                "payment": payment,
-            }
-        )
-        if deliver is not UNSET:
-            field_dict["deliver"] = deliver
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.contract_deliver_good import ContractDeliverGood
-        from ..models.contract_payment import ContractPayment
-
-        d = src_dict.copy()
-        deadline = isoparse(d.pop("deadline"))
-
-        payment = ContractPayment.from_dict(d.pop("payment"))
-
-        deliver = []
-        _deliver = d.pop("deliver", UNSET)
-        for deliver_item_data in _deliver or []:
-            deliver_item = ContractDeliverGood.from_dict(deliver_item_data)
-
-            deliver.append(deliver_item)
-
-        contract_terms = cls(
-            deadline=deadline,
-            payment=payment,
-            deliver=deliver,
-        )
-
-        contract_terms.additional_properties = d
-        return contract_terms
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/cooldown.py
+++ b/spacetraders/models/cooldown.py
@@ -15,14 +15,14 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="Cooldown")
 
 
-@attr.s(auto_attribs=True)
-class Cooldown:
+class Cooldown(BaseModel):
     """A cooldown is a period of time in which a ship cannot perform certain actions.
 
     Attributes:
@@ -32,51 +32,14 @@ class Cooldown:
         expiration (datetime.datetime): The date and time when the cooldown expires in ISO 8601 format
     """
 
-    ship_symbol: str
-    total_seconds: int
-    remaining_seconds: int
-    expiration: datetime.datetime
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    ship_symbol: str = Field(alias="shipSymbol")
+    total_seconds: int = Field(alias="totalSeconds")
+    remaining_seconds: int = Field(alias="remainingSeconds")
+    expiration: datetime.datetime = Field(alias="expiration")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        ship_symbol = self.ship_symbol
-        total_seconds = self.total_seconds
-        remaining_seconds = self.remaining_seconds
-        expiration = self.expiration.isoformat()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "shipSymbol": ship_symbol,
-                "totalSeconds": total_seconds,
-                "remainingSeconds": remaining_seconds,
-                "expiration": expiration,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        ship_symbol = d.pop("shipSymbol")
-
-        total_seconds = d.pop("totalSeconds")
-
-        remaining_seconds = d.pop("remainingSeconds")
-
-        expiration = isoparse(d.pop("expiration"))
-
-        cooldown = cls(
-            ship_symbol=ship_symbol,
-            total_seconds=total_seconds,
-            remaining_seconds=remaining_seconds,
-            expiration=expiration,
-        )
-
-        cooldown.additional_properties = d
-        return cooldown
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_chart_response_201.py
+++ b/spacetraders/models/create_chart_response_201.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.create_chart_response_201_data import CreateChartResponse201Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.create_chart_response_201_data import CreateChartResponse201Data
-
 
 T = TypeVar("T", bound="CreateChartResponse201")
 
 
-@attr.s(auto_attribs=True)
-class CreateChartResponse201:
+class CreateChartResponse201(BaseModel):
     """
     Attributes:
         data (CreateChartResponse201Data):
     """
 
-    data: "CreateChartResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "CreateChartResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.create_chart_response_201_data import CreateChartResponse201Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.create_chart_response_201_data import CreateChartResponse201Data
-
-        d = src_dict.copy()
-        data = CreateChartResponse201Data.from_dict(d.pop("data"))
-
-        create_chart_response_201 = cls(
-            data=data,
-        )
-
-        create_chart_response_201.additional_properties = d
-        return create_chart_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_chart_response_201_data.py
+++ b/spacetraders/models/create_chart_response_201_data.py
@@ -13,65 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.chart import Chart
+from ..models.waypoint import Waypoint
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.chart import Chart
-    from ..models.waypoint import Waypoint
-
 
 T = TypeVar("T", bound="CreateChartResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class CreateChartResponse201Data:
+class CreateChartResponse201Data(BaseModel):
     """
     Attributes:
         chart (Chart): The chart of a system or waypoint, which makes the location visible to other agents.
         waypoint (Waypoint): A waypoint is a location that ships can travel to such as a Planet, Moon or Space Station.
     """
 
-    chart: "Chart"
-    waypoint: "Waypoint"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    chart: "Chart" = Field(alias="chart")
+    waypoint: "Waypoint" = Field(alias="waypoint")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.chart import Chart
-        from ..models.waypoint import Waypoint
-
-        chart = self.chart.to_dict()
-
-        waypoint = self.waypoint.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "chart": chart,
-                "waypoint": waypoint,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.chart import Chart
-        from ..models.waypoint import Waypoint
-
-        d = src_dict.copy()
-        chart = Chart.from_dict(d.pop("chart"))
-
-        waypoint = Waypoint.from_dict(d.pop("waypoint"))
-
-        create_chart_response_201_data = cls(
-            chart=chart,
-            waypoint=waypoint,
-        )
-
-        create_chart_response_201_data.additional_properties = d
-        return create_chart_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_ship_ship_scan_response_201.py
+++ b/spacetraders/models/create_ship_ship_scan_response_201.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.create_ship_ship_scan_response_201_data import (
+    CreateShipShipScanResponse201Data,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.create_ship_ship_scan_response_201_data import (
-        CreateShipShipScanResponse201Data,
-    )
-
 
 T = TypeVar("T", bound="CreateShipShipScanResponse201")
 
 
-@attr.s(auto_attribs=True)
-class CreateShipShipScanResponse201:
+class CreateShipShipScanResponse201(BaseModel):
     """
     Attributes:
         data (CreateShipShipScanResponse201Data):
     """
 
-    data: "CreateShipShipScanResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "CreateShipShipScanResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.create_ship_ship_scan_response_201_data import (
-            CreateShipShipScanResponse201Data,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.create_ship_ship_scan_response_201_data import (
-            CreateShipShipScanResponse201Data,
-        )
-
-        d = src_dict.copy()
-        data = CreateShipShipScanResponse201Data.from_dict(d.pop("data"))
-
-        create_ship_ship_scan_response_201 = cls(
-            data=data,
-        )
-
-        create_ship_ship_scan_response_201.additional_properties = d
-        return create_ship_ship_scan_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_ship_ship_scan_response_201_data.py
+++ b/spacetraders/models/create_ship_ship_scan_response_201_data.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
+from ..models.scanned_ship import ScannedShip
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-    from ..models.scanned_ship import ScannedShip
-
 
 T = TypeVar("T", bound="CreateShipShipScanResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class CreateShipShipScanResponse201Data:
+class CreateShipShipScanResponse201Data(BaseModel):
     """
     Attributes:
         cooldown (Cooldown): A cooldown is a period of time in which a ship cannot perform certain actions.
         ships (List['ScannedShip']):
     """
 
-    cooldown: "Cooldown"
-    ships: List["ScannedShip"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cooldown: "Cooldown" = Field(alias="cooldown")
+    ships: List["ScannedShip"] = Field(alias="ships")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-        from ..models.scanned_ship import ScannedShip
-
-        cooldown = self.cooldown.to_dict()
-
-        ships = []
-        for ships_item_data in self.ships:
-            ships_item = ships_item_data.to_dict()
-
-            ships.append(ships_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cooldown": cooldown,
-                "ships": ships,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-        from ..models.scanned_ship import ScannedShip
-
-        d = src_dict.copy()
-        cooldown = Cooldown.from_dict(d.pop("cooldown"))
-
-        ships = []
-        _ships = d.pop("ships")
-        for ships_item_data in _ships:
-            ships_item = ScannedShip.from_dict(ships_item_data)
-
-            ships.append(ships_item)
-
-        create_ship_ship_scan_response_201_data = cls(
-            cooldown=cooldown,
-            ships=ships,
-        )
-
-        create_ship_ship_scan_response_201_data.additional_properties = d
-        return create_ship_ship_scan_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_ship_system_scan_response_201.py
+++ b/spacetraders/models/create_ship_system_scan_response_201.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.create_ship_system_scan_response_201_data import (
+    CreateShipSystemScanResponse201Data,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.create_ship_system_scan_response_201_data import (
-        CreateShipSystemScanResponse201Data,
-    )
-
 
 T = TypeVar("T", bound="CreateShipSystemScanResponse201")
 
 
-@attr.s(auto_attribs=True)
-class CreateShipSystemScanResponse201:
+class CreateShipSystemScanResponse201(BaseModel):
     """
     Attributes:
         data (CreateShipSystemScanResponse201Data):
     """
 
-    data: "CreateShipSystemScanResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "CreateShipSystemScanResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.create_ship_system_scan_response_201_data import (
-            CreateShipSystemScanResponse201Data,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.create_ship_system_scan_response_201_data import (
-            CreateShipSystemScanResponse201Data,
-        )
-
-        d = src_dict.copy()
-        data = CreateShipSystemScanResponse201Data.from_dict(d.pop("data"))
-
-        create_ship_system_scan_response_201 = cls(
-            data=data,
-        )
-
-        create_ship_system_scan_response_201.additional_properties = d
-        return create_ship_system_scan_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_ship_system_scan_response_201_data.py
+++ b/spacetraders/models/create_ship_system_scan_response_201_data.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
+from ..models.scanned_system import ScannedSystem
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-    from ..models.scanned_system import ScannedSystem
-
 
 T = TypeVar("T", bound="CreateShipSystemScanResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class CreateShipSystemScanResponse201Data:
+class CreateShipSystemScanResponse201Data(BaseModel):
     """
     Attributes:
         cooldown (Cooldown): A cooldown is a period of time in which a ship cannot perform certain actions.
         systems (List['ScannedSystem']):
     """
 
-    cooldown: "Cooldown"
-    systems: List["ScannedSystem"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cooldown: "Cooldown" = Field(alias="cooldown")
+    systems: List["ScannedSystem"] = Field(alias="systems")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-        from ..models.scanned_system import ScannedSystem
-
-        cooldown = self.cooldown.to_dict()
-
-        systems = []
-        for systems_item_data in self.systems:
-            systems_item = systems_item_data.to_dict()
-
-            systems.append(systems_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cooldown": cooldown,
-                "systems": systems,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-        from ..models.scanned_system import ScannedSystem
-
-        d = src_dict.copy()
-        cooldown = Cooldown.from_dict(d.pop("cooldown"))
-
-        systems = []
-        _systems = d.pop("systems")
-        for systems_item_data in _systems:
-            systems_item = ScannedSystem.from_dict(systems_item_data)
-
-            systems.append(systems_item)
-
-        create_ship_system_scan_response_201_data = cls(
-            cooldown=cooldown,
-            systems=systems,
-        )
-
-        create_ship_system_scan_response_201_data.additional_properties = d
-        return create_ship_system_scan_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_ship_waypoint_scan_response_201.py
+++ b/spacetraders/models/create_ship_waypoint_scan_response_201.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.create_ship_waypoint_scan_response_201_data import (
+    CreateShipWaypointScanResponse201Data,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.create_ship_waypoint_scan_response_201_data import (
-        CreateShipWaypointScanResponse201Data,
-    )
-
 
 T = TypeVar("T", bound="CreateShipWaypointScanResponse201")
 
 
-@attr.s(auto_attribs=True)
-class CreateShipWaypointScanResponse201:
+class CreateShipWaypointScanResponse201(BaseModel):
     """
     Attributes:
         data (CreateShipWaypointScanResponse201Data):
     """
 
-    data: "CreateShipWaypointScanResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "CreateShipWaypointScanResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.create_ship_waypoint_scan_response_201_data import (
-            CreateShipWaypointScanResponse201Data,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.create_ship_waypoint_scan_response_201_data import (
-            CreateShipWaypointScanResponse201Data,
-        )
-
-        d = src_dict.copy()
-        data = CreateShipWaypointScanResponse201Data.from_dict(d.pop("data"))
-
-        create_ship_waypoint_scan_response_201 = cls(
-            data=data,
-        )
-
-        create_ship_waypoint_scan_response_201.additional_properties = d
-        return create_ship_waypoint_scan_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_ship_waypoint_scan_response_201_data.py
+++ b/spacetraders/models/create_ship_waypoint_scan_response_201_data.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
+from ..models.scanned_waypoint import ScannedWaypoint
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-    from ..models.scanned_waypoint import ScannedWaypoint
-
 
 T = TypeVar("T", bound="CreateShipWaypointScanResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class CreateShipWaypointScanResponse201Data:
+class CreateShipWaypointScanResponse201Data(BaseModel):
     """
     Attributes:
         cooldown (Cooldown): A cooldown is a period of time in which a ship cannot perform certain actions.
         waypoints (List['ScannedWaypoint']):
     """
 
-    cooldown: "Cooldown"
-    waypoints: List["ScannedWaypoint"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cooldown: "Cooldown" = Field(alias="cooldown")
+    waypoints: List["ScannedWaypoint"] = Field(alias="waypoints")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-        from ..models.scanned_waypoint import ScannedWaypoint
-
-        cooldown = self.cooldown.to_dict()
-
-        waypoints = []
-        for waypoints_item_data in self.waypoints:
-            waypoints_item = waypoints_item_data.to_dict()
-
-            waypoints.append(waypoints_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cooldown": cooldown,
-                "waypoints": waypoints,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-        from ..models.scanned_waypoint import ScannedWaypoint
-
-        d = src_dict.copy()
-        cooldown = Cooldown.from_dict(d.pop("cooldown"))
-
-        waypoints = []
-        _waypoints = d.pop("waypoints")
-        for waypoints_item_data in _waypoints:
-            waypoints_item = ScannedWaypoint.from_dict(waypoints_item_data)
-
-            waypoints.append(waypoints_item)
-
-        create_ship_waypoint_scan_response_201_data = cls(
-            cooldown=cooldown,
-            waypoints=waypoints,
-        )
-
-        create_ship_waypoint_scan_response_201_data.additional_properties = d
-        return create_ship_waypoint_scan_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_survey_response_201.py
+++ b/spacetraders/models/create_survey_response_201.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.create_survey_response_201_data import CreateSurveyResponse201Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.create_survey_response_201_data import CreateSurveyResponse201Data
-
 
 T = TypeVar("T", bound="CreateSurveyResponse201")
 
 
-@attr.s(auto_attribs=True)
-class CreateSurveyResponse201:
+class CreateSurveyResponse201(BaseModel):
     """
     Attributes:
         data (CreateSurveyResponse201Data):
     """
 
-    data: "CreateSurveyResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "CreateSurveyResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.create_survey_response_201_data import CreateSurveyResponse201Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.create_survey_response_201_data import CreateSurveyResponse201Data
-
-        d = src_dict.copy()
-        data = CreateSurveyResponse201Data.from_dict(d.pop("data"))
-
-        create_survey_response_201 = cls(
-            data=data,
-        )
-
-        create_survey_response_201.additional_properties = d
-        return create_survey_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/create_survey_response_201_data.py
+++ b/spacetraders/models/create_survey_response_201_data.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
+from ..models.survey import Survey
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-    from ..models.survey import Survey
-
 
 T = TypeVar("T", bound="CreateSurveyResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class CreateSurveyResponse201Data:
+class CreateSurveyResponse201Data(BaseModel):
     """
     Attributes:
         cooldown (Cooldown): A cooldown is a period of time in which a ship cannot perform certain actions.
         surveys (List['Survey']):
     """
 
-    cooldown: "Cooldown"
-    surveys: List["Survey"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cooldown: "Cooldown" = Field(alias="cooldown")
+    surveys: List["Survey"] = Field(alias="surveys")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-        from ..models.survey import Survey
-
-        cooldown = self.cooldown.to_dict()
-
-        surveys = []
-        for surveys_item_data in self.surveys:
-            surveys_item = surveys_item_data.to_dict()
-
-            surveys.append(surveys_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cooldown": cooldown,
-                "surveys": surveys,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-        from ..models.survey import Survey
-
-        d = src_dict.copy()
-        cooldown = Cooldown.from_dict(d.pop("cooldown"))
-
-        surveys = []
-        _surveys = d.pop("surveys")
-        for surveys_item_data in _surveys:
-            surveys_item = Survey.from_dict(surveys_item_data)
-
-            surveys.append(surveys_item)
-
-        create_survey_response_201_data = cls(
-            cooldown=cooldown,
-            surveys=surveys,
-        )
-
-        create_survey_response_201_data.additional_properties = d
-        return create_survey_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/deliver_contract_json_body.py
+++ b/spacetraders/models/deliver_contract_json_body.py
@@ -12,14 +12,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="DeliverContractJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class DeliverContractJsonBody:
+class DeliverContractJsonBody(BaseModel):
     """
     Attributes:
         ship_symbol (str):
@@ -27,45 +27,13 @@ class DeliverContractJsonBody:
         units (int):
     """
 
-    ship_symbol: str
-    trade_symbol: str
-    units: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    ship_symbol: str = Field(alias="shipSymbol")
+    trade_symbol: str = Field(alias="tradeSymbol")
+    units: int = Field(alias="units")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        ship_symbol = self.ship_symbol
-        trade_symbol = self.trade_symbol
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "shipSymbol": ship_symbol,
-                "tradeSymbol": trade_symbol,
-                "units": units,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        ship_symbol = d.pop("shipSymbol")
-
-        trade_symbol = d.pop("tradeSymbol")
-
-        units = d.pop("units")
-
-        deliver_contract_json_body = cls(
-            ship_symbol=ship_symbol,
-            trade_symbol=trade_symbol,
-            units=units,
-        )
-
-        deliver_contract_json_body.additional_properties = d
-        return deliver_contract_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/deliver_contract_response_200.py
+++ b/spacetraders/models/deliver_contract_response_200.py
@@ -13,60 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.deliver_contract_response_200_data import DeliverContractResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.deliver_contract_response_200_data import (
-        DeliverContractResponse200Data,
-    )
-
 
 T = TypeVar("T", bound="DeliverContractResponse200")
 
 
-@attr.s(auto_attribs=True)
-class DeliverContractResponse200:
+class DeliverContractResponse200(BaseModel):
     """
     Attributes:
         data (DeliverContractResponse200Data):
     """
 
-    data: "DeliverContractResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "DeliverContractResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.deliver_contract_response_200_data import (
-            DeliverContractResponse200Data,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.deliver_contract_response_200_data import (
-            DeliverContractResponse200Data,
-        )
-
-        d = src_dict.copy()
-        data = DeliverContractResponse200Data.from_dict(d.pop("data"))
-
-        deliver_contract_response_200 = cls(
-            data=data,
-        )
-
-        deliver_contract_response_200.additional_properties = d
-        return deliver_contract_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/deliver_contract_response_200_data.py
+++ b/spacetraders/models/deliver_contract_response_200_data.py
@@ -13,65 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.contract import Contract
+from ..models.ship_cargo import ShipCargo
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.contract import Contract
-    from ..models.ship_cargo import ShipCargo
-
 
 T = TypeVar("T", bound="DeliverContractResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class DeliverContractResponse200Data:
+class DeliverContractResponse200Data(BaseModel):
     """
     Attributes:
         contract (Contract):
         cargo (ShipCargo):
     """
 
-    contract: "Contract"
-    cargo: "ShipCargo"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    contract: "Contract" = Field(alias="contract")
+    cargo: "ShipCargo" = Field(alias="cargo")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.contract import Contract
-        from ..models.ship_cargo import ShipCargo
-
-        contract = self.contract.to_dict()
-
-        cargo = self.cargo.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "contract": contract,
-                "cargo": cargo,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.contract import Contract
-        from ..models.ship_cargo import ShipCargo
-
-        d = src_dict.copy()
-        contract = Contract.from_dict(d.pop("contract"))
-
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        deliver_contract_response_200_data = cls(
-            contract=contract,
-            cargo=cargo,
-        )
-
-        deliver_contract_response_200_data.additional_properties = d
-        return deliver_contract_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/dock_ship_dock_ship_200_response.py
+++ b/spacetraders/models/dock_ship_dock_ship_200_response.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.dock_ship_dock_ship_200_response_data import (
+    DockShipDockShip200ResponseData,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.dock_ship_dock_ship_200_response_data import (
-        DockShipDockShip200ResponseData,
-    )
-
 
 T = TypeVar("T", bound="DockShipDockShip200Response")
 
 
-@attr.s(auto_attribs=True)
-class DockShipDockShip200Response:
+class DockShipDockShip200Response(BaseModel):
     """
     Attributes:
         data (DockShipDockShip200ResponseData):
     """
 
-    data: "DockShipDockShip200ResponseData"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "DockShipDockShip200ResponseData" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.dock_ship_dock_ship_200_response_data import (
-            DockShipDockShip200ResponseData,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.dock_ship_dock_ship_200_response_data import (
-            DockShipDockShip200ResponseData,
-        )
-
-        d = src_dict.copy()
-        data = DockShipDockShip200ResponseData.from_dict(d.pop("data"))
-
-        dock_ship_dock_ship_200_response = cls(
-            data=data,
-        )
-
-        dock_ship_dock_ship_200_response.additional_properties = d
-        return dock_ship_dock_ship_200_response
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/dock_ship_dock_ship_200_response_data.py
+++ b/spacetraders/models/dock_ship_dock_ship_200_response_data.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_nav import ShipNav
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_nav import ShipNav
-
 
 T = TypeVar("T", bound="DockShipDockShip200ResponseData")
 
 
-@attr.s(auto_attribs=True)
-class DockShipDockShip200ResponseData:
+class DockShipDockShip200ResponseData(BaseModel):
     """
     Attributes:
         nav (ShipNav): The navigation information of the ship.
     """
 
-    nav: "ShipNav"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    nav: "ShipNav" = Field(alias="nav")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_nav import ShipNav
-
-        nav = self.nav.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "nav": nav,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_nav import ShipNav
-
-        d = src_dict.copy()
-        nav = ShipNav.from_dict(d.pop("nav"))
-
-        dock_ship_dock_ship_200_response_data = cls(
-            nav=nav,
-        )
-
-        dock_ship_dock_ship_200_response_data.additional_properties = d
-        return dock_ship_dock_ship_200_response_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/extract_resources_json_body.py
+++ b/spacetraders/models/extract_resources_json_body.py
@@ -14,18 +14,15 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.survey import Survey
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.survey import Survey
-
 
 T = TypeVar("T", bound="ExtractResourcesJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class ExtractResourcesJsonBody:
+class ExtractResourcesJsonBody(BaseModel):
     """
     Attributes:
         survey (Union[Unset, Survey]): A resource survey of a waypoint, detailing a specific extraction location and the
@@ -33,41 +30,10 @@ class ExtractResourcesJsonBody:
     """
 
     survey: Union[Unset, "Survey"] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.survey import Survey
-
-        survey: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.survey, Unset):
-            survey = self.survey.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if survey is not UNSET:
-            field_dict["survey"] = survey
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.survey import Survey
-
-        d = src_dict.copy()
-        _survey = d.pop("survey", UNSET)
-        survey: Union[Unset, Survey]
-        if isinstance(_survey, Unset):
-            survey = UNSET
-        else:
-            survey = Survey.from_dict(_survey)
-
-        extract_resources_json_body = cls(
-            survey=survey,
-        )
-
-        extract_resources_json_body.additional_properties = d
-        return extract_resources_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/extract_resources_response_201.py
+++ b/spacetraders/models/extract_resources_response_201.py
@@ -13,60 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.extract_resources_response_201_data import ExtractResourcesResponse201Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.extract_resources_response_201_data import (
-        ExtractResourcesResponse201Data,
-    )
-
 
 T = TypeVar("T", bound="ExtractResourcesResponse201")
 
 
-@attr.s(auto_attribs=True)
-class ExtractResourcesResponse201:
+class ExtractResourcesResponse201(BaseModel):
     """
     Attributes:
         data (ExtractResourcesResponse201Data):
     """
 
-    data: "ExtractResourcesResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "ExtractResourcesResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.extract_resources_response_201_data import (
-            ExtractResourcesResponse201Data,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.extract_resources_response_201_data import (
-            ExtractResourcesResponse201Data,
-        )
-
-        d = src_dict.copy()
-        data = ExtractResourcesResponse201Data.from_dict(d.pop("data"))
-
-        extract_resources_response_201 = cls(
-            data=data,
-        )
-
-        extract_resources_response_201.additional_properties = d
-        return extract_resources_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/extract_resources_response_201_data.py
+++ b/spacetraders/models/extract_resources_response_201_data.py
@@ -13,20 +13,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
+from ..models.extraction import Extraction
+from ..models.ship_cargo import ShipCargo
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-    from ..models.extraction import Extraction
-    from ..models.ship_cargo import ShipCargo
-
 
 T = TypeVar("T", bound="ExtractResourcesResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class ExtractResourcesResponse201Data:
+class ExtractResourcesResponse201Data(BaseModel):
     """
     Attributes:
         cooldown (Cooldown): A cooldown is a period of time in which a ship cannot perform certain actions.
@@ -34,55 +31,13 @@ class ExtractResourcesResponse201Data:
         cargo (ShipCargo):
     """
 
-    cooldown: "Cooldown"
-    extraction: "Extraction"
-    cargo: "ShipCargo"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cooldown: "Cooldown" = Field(alias="cooldown")
+    extraction: "Extraction" = Field(alias="extraction")
+    cargo: "ShipCargo" = Field(alias="cargo")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-        from ..models.extraction import Extraction
-        from ..models.ship_cargo import ShipCargo
-
-        cooldown = self.cooldown.to_dict()
-
-        extraction = self.extraction.to_dict()
-
-        cargo = self.cargo.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cooldown": cooldown,
-                "extraction": extraction,
-                "cargo": cargo,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-        from ..models.extraction import Extraction
-        from ..models.ship_cargo import ShipCargo
-
-        d = src_dict.copy()
-        cooldown = Cooldown.from_dict(d.pop("cooldown"))
-
-        extraction = Extraction.from_dict(d.pop("extraction"))
-
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        extract_resources_response_201_data = cls(
-            cooldown=cooldown,
-            extraction=extraction,
-            cargo=cargo,
-        )
-
-        extract_resources_response_201_data.additional_properties = d
-        return extract_resources_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/extraction.py
+++ b/spacetraders/models/extraction.py
@@ -13,61 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.extraction_yield import ExtractionYield
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.extraction_yield import ExtractionYield
-
 
 T = TypeVar("T", bound="Extraction")
 
 
-@attr.s(auto_attribs=True)
-class Extraction:
+class Extraction(BaseModel):
     """
     Attributes:
         ship_symbol (str):
         yield_ (ExtractionYield):
     """
 
-    ship_symbol: str
-    yield_: "ExtractionYield"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    ship_symbol: str = Field(alias="shipSymbol")
+    yield_: "ExtractionYield" = Field(alias="yield")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.extraction_yield import ExtractionYield
-
-        ship_symbol = self.ship_symbol
-        yield_ = self.yield_.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "shipSymbol": ship_symbol,
-                "yield": yield_,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.extraction_yield import ExtractionYield
-
-        d = src_dict.copy()
-        ship_symbol = d.pop("shipSymbol")
-
-        yield_ = ExtractionYield.from_dict(d.pop("yield"))
-
-        extraction = cls(
-            ship_symbol=ship_symbol,
-            yield_=yield_,
-        )
-
-        extraction.additional_properties = d
-        return extraction
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/extraction_yield.py
+++ b/spacetraders/models/extraction_yield.py
@@ -12,53 +12,26 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ExtractionYield")
 
 
-@attr.s(auto_attribs=True)
-class ExtractionYield:
+class ExtractionYield(BaseModel):
     """
     Attributes:
         symbol (str):
         units (int): The number of units extracted that were placed into the ship's cargo hold.
     """
 
-    symbol: str
-    units: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    units: int = Field(alias="units")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "units": units,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        units = d.pop("units")
-
-        extraction_yield = cls(
-            symbol=symbol,
-            units=units,
-        )
-
-        extraction_yield.additional_properties = d
-        return extraction_yield
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/faction.py
+++ b/spacetraders/models/faction.py
@@ -13,18 +13,15 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.faction_trait import FactionTrait
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.faction_trait import FactionTrait
-
 
 T = TypeVar("T", bound="Faction")
 
 
-@attr.s(auto_attribs=True)
-class Faction:
+class Faction(BaseModel):
     """
     Attributes:
         symbol (str):
@@ -34,70 +31,15 @@ class Faction:
         traits (List['FactionTrait']):
     """
 
-    symbol: str
-    name: str
-    description: str
-    headquarters: str
-    traits: List["FactionTrait"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    headquarters: str = Field(alias="headquarters")
+    traits: List["FactionTrait"] = Field(alias="traits")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.faction_trait import FactionTrait
-
-        symbol = self.symbol
-        name = self.name
-        description = self.description
-        headquarters = self.headquarters
-        traits = []
-        for traits_item_data in self.traits:
-            traits_item = traits_item_data.to_dict()
-
-            traits.append(traits_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-                "headquarters": headquarters,
-                "traits": traits,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.faction_trait import FactionTrait
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        headquarters = d.pop("headquarters")
-
-        traits = []
-        _traits = d.pop("traits")
-        for traits_item_data in _traits:
-            traits_item = FactionTrait.from_dict(traits_item_data)
-
-            traits.append(traits_item)
-
-        faction = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-            headquarters=headquarters,
-            traits=traits,
-        )
-
-        faction.additional_properties = d
-        return faction
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/faction_trait.py
+++ b/spacetraders/models/faction_trait.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.faction_trait_symbol import FactionTraitSymbol
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="FactionTrait")
 
 
-@attr.s(auto_attribs=True)
-class FactionTrait:
+class FactionTrait(BaseModel):
     """
     Attributes:
         symbol (FactionTraitSymbol): The unique identifier of the trait.
@@ -28,46 +28,13 @@ class FactionTrait:
         description (str): A description of the trait.
     """
 
-    symbol: FactionTraitSymbol
-    name: str
-    description: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: FactionTraitSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol.value
-
-        name = self.name
-        description = self.description
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = FactionTraitSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        faction_trait = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-        )
-
-        faction_trait.additional_properties = d
-        return faction_trait
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/fulfill_contract_response_200.py
+++ b/spacetraders/models/fulfill_contract_response_200.py
@@ -13,60 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.fulfill_contract_response_200_data import FulfillContractResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.fulfill_contract_response_200_data import (
-        FulfillContractResponse200Data,
-    )
-
 
 T = TypeVar("T", bound="FulfillContractResponse200")
 
 
-@attr.s(auto_attribs=True)
-class FulfillContractResponse200:
+class FulfillContractResponse200(BaseModel):
     """
     Attributes:
         data (FulfillContractResponse200Data):
     """
 
-    data: "FulfillContractResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "FulfillContractResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.fulfill_contract_response_200_data import (
-            FulfillContractResponse200Data,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.fulfill_contract_response_200_data import (
-            FulfillContractResponse200Data,
-        )
-
-        d = src_dict.copy()
-        data = FulfillContractResponse200Data.from_dict(d.pop("data"))
-
-        fulfill_contract_response_200 = cls(
-            data=data,
-        )
-
-        fulfill_contract_response_200.additional_properties = d
-        return fulfill_contract_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/fulfill_contract_response_200_data.py
+++ b/spacetraders/models/fulfill_contract_response_200_data.py
@@ -13,65 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
+from ..models.contract import Contract
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-    from ..models.contract import Contract
-
 
 T = TypeVar("T", bound="FulfillContractResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class FulfillContractResponse200Data:
+class FulfillContractResponse200Data(BaseModel):
     """
     Attributes:
         agent (Agent):
         contract (Contract):
     """
 
-    agent: "Agent"
-    contract: "Contract"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    agent: "Agent" = Field(alias="agent")
+    contract: "Contract" = Field(alias="contract")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-        from ..models.contract import Contract
-
-        agent = self.agent.to_dict()
-
-        contract = self.contract.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "agent": agent,
-                "contract": contract,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-        from ..models.contract import Contract
-
-        d = src_dict.copy()
-        agent = Agent.from_dict(d.pop("agent"))
-
-        contract = Contract.from_dict(d.pop("contract"))
-
-        fulfill_contract_response_200_data = cls(
-            agent=agent,
-            contract=contract,
-        )
-
-        fulfill_contract_response_200_data.additional_properties = d
-        return fulfill_contract_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_contract_response_200.py
+++ b/spacetraders/models/get_contract_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.contract import Contract
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.contract import Contract
-
 
 T = TypeVar("T", bound="GetContractResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetContractResponse200:
+class GetContractResponse200(BaseModel):
     """
     Attributes:
         data (Contract):
     """
 
-    data: "Contract"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Contract" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.contract import Contract
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.contract import Contract
-
-        d = src_dict.copy()
-        data = Contract.from_dict(d.pop("data"))
-
-        get_contract_response_200 = cls(
-            data=data,
-        )
-
-        get_contract_response_200.additional_properties = d
-        return get_contract_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_contracts_response_200.py
+++ b/spacetraders/models/get_contracts_response_200.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.contract import Contract
+from ..models.meta import Meta
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.contract import Contract
-    from ..models.meta import Meta
-
 
 T = TypeVar("T", bound="GetContractsResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetContractsResponse200:
+class GetContractsResponse200(BaseModel):
     """
     Attributes:
         data (List['Contract']):
         meta (Meta):
     """
 
-    data: List["Contract"]
-    meta: "Meta"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: List["Contract"] = Field(alias="data")
+    meta: "Meta" = Field(alias="meta")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.contract import Contract
-        from ..models.meta import Meta
-
-        data = []
-        for data_item_data in self.data:
-            data_item = data_item_data.to_dict()
-
-            data.append(data_item)
-
-        meta = self.meta.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-                "meta": meta,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.contract import Contract
-        from ..models.meta import Meta
-
-        d = src_dict.copy()
-        data = []
-        _data = d.pop("data")
-        for data_item_data in _data:
-            data_item = Contract.from_dict(data_item_data)
-
-            data.append(data_item)
-
-        meta = Meta.from_dict(d.pop("meta"))
-
-        get_contracts_response_200 = cls(
-            data=data,
-            meta=meta,
-        )
-
-        get_contracts_response_200.additional_properties = d
-        return get_contracts_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_faction_response_200.py
+++ b/spacetraders/models/get_faction_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.faction import Faction
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.faction import Faction
-
 
 T = TypeVar("T", bound="GetFactionResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetFactionResponse200:
+class GetFactionResponse200(BaseModel):
     """
     Attributes:
         data (Faction):
     """
 
-    data: "Faction"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Faction" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.faction import Faction
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.faction import Faction
-
-        d = src_dict.copy()
-        data = Faction.from_dict(d.pop("data"))
-
-        get_faction_response_200 = cls(
-            data=data,
-        )
-
-        get_faction_response_200.additional_properties = d
-        return get_faction_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_factions_response_200.py
+++ b/spacetraders/models/get_factions_response_200.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.faction import Faction
+from ..models.meta import Meta
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.faction import Faction
-    from ..models.meta import Meta
-
 
 T = TypeVar("T", bound="GetFactionsResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetFactionsResponse200:
+class GetFactionsResponse200(BaseModel):
     """
     Attributes:
         data (List['Faction']):
         meta (Meta):
     """
 
-    data: List["Faction"]
-    meta: "Meta"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: List["Faction"] = Field(alias="data")
+    meta: "Meta" = Field(alias="meta")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.faction import Faction
-        from ..models.meta import Meta
-
-        data = []
-        for data_item_data in self.data:
-            data_item = data_item_data.to_dict()
-
-            data.append(data_item)
-
-        meta = self.meta.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-                "meta": meta,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.faction import Faction
-        from ..models.meta import Meta
-
-        d = src_dict.copy()
-        data = []
-        _data = d.pop("data")
-        for data_item_data in _data:
-            data_item = Faction.from_dict(data_item_data)
-
-            data.append(data_item)
-
-        meta = Meta.from_dict(d.pop("meta"))
-
-        get_factions_response_200 = cls(
-            data=data,
-            meta=meta,
-        )
-
-        get_factions_response_200.additional_properties = d
-        return get_factions_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_jump_gate_response_200.py
+++ b/spacetraders/models/get_jump_gate_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.jump_gate import JumpGate
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.jump_gate import JumpGate
-
 
 T = TypeVar("T", bound="GetJumpGateResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetJumpGateResponse200:
+class GetJumpGateResponse200(BaseModel):
     """
     Attributes:
         data (JumpGate):
     """
 
-    data: "JumpGate"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "JumpGate" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.jump_gate import JumpGate
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.jump_gate import JumpGate
-
-        d = src_dict.copy()
-        data = JumpGate.from_dict(d.pop("data"))
-
-        get_jump_gate_response_200 = cls(
-            data=data,
-        )
-
-        get_jump_gate_response_200.additional_properties = d
-        return get_jump_gate_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_market_response_200.py
+++ b/spacetraders/models/get_market_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.market import Market
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.market import Market
-
 
 T = TypeVar("T", bound="GetMarketResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetMarketResponse200:
+class GetMarketResponse200(BaseModel):
     """
     Attributes:
         data (Market):
     """
 
-    data: "Market"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Market" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.market import Market
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.market import Market
-
-        d = src_dict.copy()
-        data = Market.from_dict(d.pop("data"))
-
-        get_market_response_200 = cls(
-            data=data,
-        )
-
-        get_market_response_200.additional_properties = d
-        return get_market_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_my_agent_response_200.py
+++ b/spacetraders/models/get_my_agent_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-
 
 T = TypeVar("T", bound="GetMyAgentResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetMyAgentResponse200:
+class GetMyAgentResponse200(BaseModel):
     """
     Attributes:
         data (Agent):
     """
 
-    data: "Agent"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Agent" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-
-        d = src_dict.copy()
-        data = Agent.from_dict(d.pop("data"))
-
-        get_my_agent_response_200 = cls(
-            data=data,
-        )
-
-        get_my_agent_response_200.additional_properties = d
-        return get_my_agent_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_my_ship_cargo_response_200.py
+++ b/spacetraders/models/get_my_ship_cargo_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_cargo import ShipCargo
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_cargo import ShipCargo
-
 
 T = TypeVar("T", bound="GetMyShipCargoResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetMyShipCargoResponse200:
+class GetMyShipCargoResponse200(BaseModel):
     """
     Attributes:
         data (ShipCargo):
     """
 
-    data: "ShipCargo"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "ShipCargo" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_cargo import ShipCargo
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_cargo import ShipCargo
-
-        d = src_dict.copy()
-        data = ShipCargo.from_dict(d.pop("data"))
-
-        get_my_ship_cargo_response_200 = cls(
-            data=data,
-        )
-
-        get_my_ship_cargo_response_200.additional_properties = d
-        return get_my_ship_cargo_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_my_ship_response_200.py
+++ b/spacetraders/models/get_my_ship_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship import Ship
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship import Ship
-
 
 T = TypeVar("T", bound="GetMyShipResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetMyShipResponse200:
+class GetMyShipResponse200(BaseModel):
     """
     Attributes:
         data (Ship): A ship
     """
 
-    data: "Ship"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Ship" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship import Ship
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship import Ship
-
-        d = src_dict.copy()
-        data = Ship.from_dict(d.pop("data"))
-
-        get_my_ship_response_200 = cls(
-            data=data,
-        )
-
-        get_my_ship_response_200.additional_properties = d
-        return get_my_ship_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_my_ships_response_200.py
+++ b/spacetraders/models/get_my_ships_response_200.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.meta import Meta
+from ..models.ship import Ship
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.meta import Meta
-    from ..models.ship import Ship
-
 
 T = TypeVar("T", bound="GetMyShipsResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetMyShipsResponse200:
+class GetMyShipsResponse200(BaseModel):
     """
     Attributes:
         data (List['Ship']):
         meta (Meta):
     """
 
-    data: List["Ship"]
-    meta: "Meta"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: List["Ship"] = Field(alias="data")
+    meta: "Meta" = Field(alias="meta")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.meta import Meta
-        from ..models.ship import Ship
-
-        data = []
-        for data_item_data in self.data:
-            data_item = data_item_data.to_dict()
-
-            data.append(data_item)
-
-        meta = self.meta.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-                "meta": meta,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.meta import Meta
-        from ..models.ship import Ship
-
-        d = src_dict.copy()
-        data = []
-        _data = d.pop("data")
-        for data_item_data in _data:
-            data_item = Ship.from_dict(data_item_data)
-
-            data.append(data_item)
-
-        meta = Meta.from_dict(d.pop("meta"))
-
-        get_my_ships_response_200 = cls(
-            data=data,
-            meta=meta,
-        )
-
-        get_my_ships_response_200.additional_properties = d
-        return get_my_ships_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_ship_cooldown_response_200.py
+++ b/spacetraders/models/get_ship_cooldown_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-
 
 T = TypeVar("T", bound="GetShipCooldownResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetShipCooldownResponse200:
+class GetShipCooldownResponse200(BaseModel):
     """
     Attributes:
         data (Cooldown): A cooldown is a period of time in which a ship cannot perform certain actions.
     """
 
-    data: "Cooldown"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Cooldown" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-
-        d = src_dict.copy()
-        data = Cooldown.from_dict(d.pop("data"))
-
-        get_ship_cooldown_response_200 = cls(
-            data=data,
-        )
-
-        get_ship_cooldown_response_200.additional_properties = d
-        return get_ship_cooldown_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_ship_nav_response_200.py
+++ b/spacetraders/models/get_ship_nav_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_nav import ShipNav
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_nav import ShipNav
-
 
 T = TypeVar("T", bound="GetShipNavResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetShipNavResponse200:
+class GetShipNavResponse200(BaseModel):
     """
     Attributes:
         data (ShipNav): The navigation information of the ship.
     """
 
-    data: "ShipNav"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "ShipNav" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_nav import ShipNav
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_nav import ShipNav
-
-        d = src_dict.copy()
-        data = ShipNav.from_dict(d.pop("data"))
-
-        get_ship_nav_response_200 = cls(
-            data=data,
-        )
-
-        get_ship_nav_response_200.additional_properties = d
-        return get_ship_nav_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_shipyard_response_200.py
+++ b/spacetraders/models/get_shipyard_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.shipyard import Shipyard
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.shipyard import Shipyard
-
 
 T = TypeVar("T", bound="GetShipyardResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetShipyardResponse200:
+class GetShipyardResponse200(BaseModel):
     """
     Attributes:
         data (Shipyard):
     """
 
-    data: "Shipyard"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Shipyard" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.shipyard import Shipyard
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.shipyard import Shipyard
-
-        d = src_dict.copy()
-        data = Shipyard.from_dict(d.pop("data"))
-
-        get_shipyard_response_200 = cls(
-            data=data,
-        )
-
-        get_shipyard_response_200.additional_properties = d
-        return get_shipyard_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_system_response_200.py
+++ b/spacetraders/models/get_system_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.system import System
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.system import System
-
 
 T = TypeVar("T", bound="GetSystemResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetSystemResponse200:
+class GetSystemResponse200(BaseModel):
     """
     Attributes:
         data (System):
     """
 
-    data: "System"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "System" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.system import System
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.system import System
-
-        d = src_dict.copy()
-        data = System.from_dict(d.pop("data"))
-
-        get_system_response_200 = cls(
-            data=data,
-        )
-
-        get_system_response_200.additional_properties = d
-        return get_system_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_system_waypoints_response_200.py
+++ b/spacetraders/models/get_system_waypoints_response_200.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.meta import Meta
+from ..models.waypoint import Waypoint
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.meta import Meta
-    from ..models.waypoint import Waypoint
-
 
 T = TypeVar("T", bound="GetSystemWaypointsResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetSystemWaypointsResponse200:
+class GetSystemWaypointsResponse200(BaseModel):
     """
     Attributes:
         data (List['Waypoint']):
         meta (Meta):
     """
 
-    data: List["Waypoint"]
-    meta: "Meta"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: List["Waypoint"] = Field(alias="data")
+    meta: "Meta" = Field(alias="meta")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.meta import Meta
-        from ..models.waypoint import Waypoint
-
-        data = []
-        for data_item_data in self.data:
-            data_item = data_item_data.to_dict()
-
-            data.append(data_item)
-
-        meta = self.meta.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-                "meta": meta,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.meta import Meta
-        from ..models.waypoint import Waypoint
-
-        d = src_dict.copy()
-        data = []
-        _data = d.pop("data")
-        for data_item_data in _data:
-            data_item = Waypoint.from_dict(data_item_data)
-
-            data.append(data_item)
-
-        meta = Meta.from_dict(d.pop("meta"))
-
-        get_system_waypoints_response_200 = cls(
-            data=data,
-            meta=meta,
-        )
-
-        get_system_waypoints_response_200.additional_properties = d
-        return get_system_waypoints_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_systems_response_200.py
+++ b/spacetraders/models/get_systems_response_200.py
@@ -13,74 +13,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.meta import Meta
+from ..models.system import System
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.meta import Meta
-    from ..models.system import System
-
 
 T = TypeVar("T", bound="GetSystemsResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetSystemsResponse200:
+class GetSystemsResponse200(BaseModel):
     """
     Attributes:
         data (List['System']):
         meta (Meta):
     """
 
-    data: List["System"]
-    meta: "Meta"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: List["System"] = Field(alias="data")
+    meta: "Meta" = Field(alias="meta")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.meta import Meta
-        from ..models.system import System
-
-        data = []
-        for data_item_data in self.data:
-            data_item = data_item_data.to_dict()
-
-            data.append(data_item)
-
-        meta = self.meta.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-                "meta": meta,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.meta import Meta
-        from ..models.system import System
-
-        d = src_dict.copy()
-        data = []
-        _data = d.pop("data")
-        for data_item_data in _data:
-            data_item = System.from_dict(data_item_data)
-
-            data.append(data_item)
-
-        meta = Meta.from_dict(d.pop("meta"))
-
-        get_systems_response_200 = cls(
-            data=data,
-            meta=meta,
-        )
-
-        get_systems_response_200.additional_properties = d
-        return get_systems_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/get_waypoint_response_200.py
+++ b/spacetraders/models/get_waypoint_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.waypoint import Waypoint
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.waypoint import Waypoint
-
 
 T = TypeVar("T", bound="GetWaypointResponse200")
 
 
-@attr.s(auto_attribs=True)
-class GetWaypointResponse200:
+class GetWaypointResponse200(BaseModel):
     """
     Attributes:
         data (Waypoint): A waypoint is a location that ships can travel to such as a Planet, Moon or Space Station.
     """
 
-    data: "Waypoint"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "Waypoint" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.waypoint import Waypoint
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.waypoint import Waypoint
-
-        d = src_dict.copy()
-        data = Waypoint.from_dict(d.pop("data"))
-
-        get_waypoint_response_200 = cls(
-            data=data,
-        )
-
-        get_waypoint_response_200.additional_properties = d
-        return get_waypoint_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/jettison_json_body.py
+++ b/spacetraders/models/jettison_json_body.py
@@ -12,53 +12,26 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="JettisonJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class JettisonJsonBody:
+class JettisonJsonBody(BaseModel):
     """
     Attributes:
         symbol (str):
         units (int):
     """
 
-    symbol: str
-    units: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    units: int = Field(alias="units")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "units": units,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        units = d.pop("units")
-
-        jettison_json_body = cls(
-            symbol=symbol,
-            units=units,
-        )
-
-        jettison_json_body.additional_properties = d
-        return jettison_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/jettison_response_200.py
+++ b/spacetraders/models/jettison_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.jettison_response_200_data import JettisonResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.jettison_response_200_data import JettisonResponse200Data
-
 
 T = TypeVar("T", bound="JettisonResponse200")
 
 
-@attr.s(auto_attribs=True)
-class JettisonResponse200:
+class JettisonResponse200(BaseModel):
     """
     Attributes:
         data (JettisonResponse200Data):
     """
 
-    data: "JettisonResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "JettisonResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.jettison_response_200_data import JettisonResponse200Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.jettison_response_200_data import JettisonResponse200Data
-
-        d = src_dict.copy()
-        data = JettisonResponse200Data.from_dict(d.pop("data"))
-
-        jettison_response_200 = cls(
-            data=data,
-        )
-
-        jettison_response_200.additional_properties = d
-        return jettison_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/jettison_response_200_data.py
+++ b/spacetraders/models/jettison_response_200_data.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_cargo import ShipCargo
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_cargo import ShipCargo
-
 
 T = TypeVar("T", bound="JettisonResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class JettisonResponse200Data:
+class JettisonResponse200Data(BaseModel):
     """
     Attributes:
         cargo (ShipCargo):
     """
 
-    cargo: "ShipCargo"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cargo: "ShipCargo" = Field(alias="cargo")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_cargo import ShipCargo
-
-        cargo = self.cargo.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cargo": cargo,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_cargo import ShipCargo
-
-        d = src_dict.copy()
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        jettison_response_200_data = cls(
-            cargo=cargo,
-        )
-
-        jettison_response_200_data.additional_properties = d
-        return jettison_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/jump_gate.py
+++ b/spacetraders/models/jump_gate.py
@@ -14,18 +14,15 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.connected_system import ConnectedSystem
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.connected_system import ConnectedSystem
-
 
 T = TypeVar("T", bound="JumpGate")
 
 
-@attr.s(auto_attribs=True)
-class JumpGate:
+class JumpGate(BaseModel):
     """
     Attributes:
         jump_range (float): The maximum jump range of the gate.
@@ -34,62 +31,13 @@ class JumpGate:
         faction_symbol (Union[Unset, str]): The symbol of the faction that owns the gate.
     """
 
-    jump_range: float
-    connected_systems: List["ConnectedSystem"]
+    jump_range: float = Field(alias="jumpRange")
+    connected_systems: List["ConnectedSystem"] = Field(alias="connectedSystems")
     faction_symbol: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.connected_system import ConnectedSystem
-
-        jump_range = self.jump_range
-        connected_systems = []
-        for connected_systems_item_data in self.connected_systems:
-            connected_systems_item = connected_systems_item_data.to_dict()
-
-            connected_systems.append(connected_systems_item)
-
-        faction_symbol = self.faction_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "jumpRange": jump_range,
-                "connectedSystems": connected_systems,
-            }
-        )
-        if faction_symbol is not UNSET:
-            field_dict["factionSymbol"] = faction_symbol
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.connected_system import ConnectedSystem
-
-        d = src_dict.copy()
-        jump_range = d.pop("jumpRange")
-
-        connected_systems = []
-        _connected_systems = d.pop("connectedSystems")
-        for connected_systems_item_data in _connected_systems:
-            connected_systems_item = ConnectedSystem.from_dict(
-                connected_systems_item_data
-            )
-
-            connected_systems.append(connected_systems_item)
-
-        faction_symbol = d.pop("factionSymbol", UNSET)
-
-        jump_gate = cls(
-            jump_range=jump_range,
-            connected_systems=connected_systems,
-            faction_symbol=faction_symbol,
-        )
-
-        jump_gate.additional_properties = d
-        return jump_gate
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/jump_ship_json_body.py
+++ b/spacetraders/models/jump_ship_json_body.py
@@ -12,46 +12,24 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="JumpShipJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class JumpShipJsonBody:
+class JumpShipJsonBody(BaseModel):
     """
     Attributes:
         system_symbol (str): The system symbol to jump to.
     """
 
-    system_symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    system_symbol: str = Field(alias="systemSymbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        system_symbol = self.system_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "systemSymbol": system_symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        system_symbol = d.pop("systemSymbol")
-
-        jump_ship_json_body = cls(
-            system_symbol=system_symbol,
-        )
-
-        jump_ship_json_body.additional_properties = d
-        return jump_ship_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/jump_ship_response_200.py
+++ b/spacetraders/models/jump_ship_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.jump_ship_response_200_data import JumpShipResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.jump_ship_response_200_data import JumpShipResponse200Data
-
 
 T = TypeVar("T", bound="JumpShipResponse200")
 
 
-@attr.s(auto_attribs=True)
-class JumpShipResponse200:
+class JumpShipResponse200(BaseModel):
     """
     Attributes:
         data (JumpShipResponse200Data):
     """
 
-    data: "JumpShipResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "JumpShipResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.jump_ship_response_200_data import JumpShipResponse200Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.jump_ship_response_200_data import JumpShipResponse200Data
-
-        d = src_dict.copy()
-        data = JumpShipResponse200Data.from_dict(d.pop("data"))
-
-        jump_ship_response_200 = cls(
-            data=data,
-        )
-
-        jump_ship_response_200.additional_properties = d
-        return jump_ship_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/jump_ship_response_200_data.py
+++ b/spacetraders/models/jump_ship_response_200_data.py
@@ -14,73 +14,28 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
+from ..models.ship_nav import ShipNav
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-    from ..models.ship_nav import ShipNav
-
 
 T = TypeVar("T", bound="JumpShipResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class JumpShipResponse200Data:
+class JumpShipResponse200Data(BaseModel):
     """
     Attributes:
         cooldown (Cooldown): A cooldown is a period of time in which a ship cannot perform certain actions.
         nav (Union[Unset, ShipNav]): The navigation information of the ship.
     """
 
-    cooldown: "Cooldown"
+    cooldown: "Cooldown" = Field(alias="cooldown")
     nav: Union[Unset, "ShipNav"] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-        from ..models.ship_nav import ShipNav
-
-        cooldown = self.cooldown.to_dict()
-
-        nav: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.nav, Unset):
-            nav = self.nav.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cooldown": cooldown,
-            }
-        )
-        if nav is not UNSET:
-            field_dict["nav"] = nav
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-        from ..models.ship_nav import ShipNav
-
-        d = src_dict.copy()
-        cooldown = Cooldown.from_dict(d.pop("cooldown"))
-
-        _nav = d.pop("nav", UNSET)
-        nav: Union[Unset, ShipNav]
-        if isinstance(_nav, Unset):
-            nav = UNSET
-        else:
-            nav = ShipNav.from_dict(_nav)
-
-        jump_ship_response_200_data = cls(
-            cooldown=cooldown,
-            nav=nav,
-        )
-
-        jump_ship_response_200_data.additional_properties = d
-        return jump_ship_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/market.py
+++ b/spacetraders/models/market.py
@@ -14,20 +14,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.market_trade_good import MarketTradeGood
+from ..models.market_transaction import MarketTransaction
+from ..models.trade_good import TradeGood
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.market_trade_good import MarketTradeGood
-    from ..models.market_transaction import MarketTransaction
-    from ..models.trade_good import TradeGood
-
 
 T = TypeVar("T", bound="Market")
 
 
-@attr.s(auto_attribs=True)
-class Market:
+class Market(BaseModel):
     """
     Attributes:
         symbol (str): The symbol of the market. The symbol is the same as the waypoint where the market is located.
@@ -40,126 +37,16 @@ class Market:
             only when a ship is present at the market.
     """
 
-    symbol: str
-    exports: List["TradeGood"]
-    imports: List["TradeGood"]
-    exchange: List["TradeGood"]
+    symbol: str = Field(alias="symbol")
+    exports: List["TradeGood"] = Field(alias="exports")
+    imports: List["TradeGood"] = Field(alias="imports")
+    exchange: List["TradeGood"] = Field(alias="exchange")
     transactions: Union[Unset, List["MarketTransaction"]] = UNSET
     trade_goods: Union[Unset, List["MarketTradeGood"]] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.market_trade_good import MarketTradeGood
-        from ..models.market_transaction import MarketTransaction
-        from ..models.trade_good import TradeGood
-
-        symbol = self.symbol
-        exports = []
-        for exports_item_data in self.exports:
-            exports_item = exports_item_data.to_dict()
-
-            exports.append(exports_item)
-
-        imports = []
-        for imports_item_data in self.imports:
-            imports_item = imports_item_data.to_dict()
-
-            imports.append(imports_item)
-
-        exchange = []
-        for exchange_item_data in self.exchange:
-            exchange_item = exchange_item_data.to_dict()
-
-            exchange.append(exchange_item)
-
-        transactions: Union[Unset, List[Dict[str, Any]]] = UNSET
-        if not isinstance(self.transactions, Unset):
-            transactions = []
-            for transactions_item_data in self.transactions:
-                transactions_item = transactions_item_data.to_dict()
-
-                transactions.append(transactions_item)
-
-        trade_goods: Union[Unset, List[Dict[str, Any]]] = UNSET
-        if not isinstance(self.trade_goods, Unset):
-            trade_goods = []
-            for trade_goods_item_data in self.trade_goods:
-                trade_goods_item = trade_goods_item_data.to_dict()
-
-                trade_goods.append(trade_goods_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "exports": exports,
-                "imports": imports,
-                "exchange": exchange,
-            }
-        )
-        if transactions is not UNSET:
-            field_dict["transactions"] = transactions
-        if trade_goods is not UNSET:
-            field_dict["tradeGoods"] = trade_goods
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.market_trade_good import MarketTradeGood
-        from ..models.market_transaction import MarketTransaction
-        from ..models.trade_good import TradeGood
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        exports = []
-        _exports = d.pop("exports")
-        for exports_item_data in _exports:
-            exports_item = TradeGood.from_dict(exports_item_data)
-
-            exports.append(exports_item)
-
-        imports = []
-        _imports = d.pop("imports")
-        for imports_item_data in _imports:
-            imports_item = TradeGood.from_dict(imports_item_data)
-
-            imports.append(imports_item)
-
-        exchange = []
-        _exchange = d.pop("exchange")
-        for exchange_item_data in _exchange:
-            exchange_item = TradeGood.from_dict(exchange_item_data)
-
-            exchange.append(exchange_item)
-
-        transactions = []
-        _transactions = d.pop("transactions", UNSET)
-        for transactions_item_data in _transactions or []:
-            transactions_item = MarketTransaction.from_dict(transactions_item_data)
-
-            transactions.append(transactions_item)
-
-        trade_goods = []
-        _trade_goods = d.pop("tradeGoods", UNSET)
-        for trade_goods_item_data in _trade_goods or []:
-            trade_goods_item = MarketTradeGood.from_dict(trade_goods_item_data)
-
-            trade_goods.append(trade_goods_item)
-
-        market = cls(
-            symbol=symbol,
-            exports=exports,
-            imports=imports,
-            exchange=exchange,
-            transactions=transactions,
-            trade_goods=trade_goods,
-        )
-
-        market.additional_properties = d
-        return market
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/market_trade_good.py
+++ b/spacetraders/models/market_trade_good.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.market_trade_good_supply import MarketTradeGoodSupply
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="MarketTradeGood")
 
 
-@attr.s(auto_attribs=True)
-class MarketTradeGood:
+class MarketTradeGood(BaseModel):
     """
     Attributes:
         symbol (str): The symbol of the trade good.
@@ -31,58 +31,15 @@ class MarketTradeGood:
         sell_price (int): The price at which this good can be sold to the market.
     """
 
-    symbol: str
-    trade_volume: int
-    supply: MarketTradeGoodSupply
-    purchase_price: int
-    sell_price: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    trade_volume: int = Field(alias="tradeVolume")
+    supply: MarketTradeGoodSupply = Field(alias="supply")
+    purchase_price: int = Field(alias="purchasePrice")
+    sell_price: int = Field(alias="sellPrice")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        trade_volume = self.trade_volume
-        supply = self.supply.value
-
-        purchase_price = self.purchase_price
-        sell_price = self.sell_price
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "tradeVolume": trade_volume,
-                "supply": supply,
-                "purchasePrice": purchase_price,
-                "sellPrice": sell_price,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        trade_volume = d.pop("tradeVolume")
-
-        supply = MarketTradeGoodSupply(d.pop("supply"))
-
-        purchase_price = d.pop("purchasePrice")
-
-        sell_price = d.pop("sellPrice")
-
-        market_trade_good = cls(
-            symbol=symbol,
-            trade_volume=trade_volume,
-            supply=supply,
-            purchase_price=purchase_price,
-            sell_price=sell_price,
-        )
-
-        market_trade_good.additional_properties = d
-        return market_trade_good
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/market_transaction.py
+++ b/spacetraders/models/market_transaction.py
@@ -15,6 +15,7 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
 from ..models.market_transaction_type import MarketTransactionType
 from ..types import UNSET, Unset
@@ -22,8 +23,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="MarketTransaction")
 
 
-@attr.s(auto_attribs=True)
-class MarketTransaction:
+class MarketTransaction(BaseModel):
     """
     Attributes:
         waypoint_symbol (str): The symbol of the waypoint where the transaction took place.
@@ -36,76 +36,18 @@ class MarketTransaction:
         timestamp (datetime.datetime): The timestamp of the transaction.
     """
 
-    waypoint_symbol: str
-    ship_symbol: str
-    trade_symbol: str
-    type: MarketTransactionType
-    units: int
-    price_per_unit: int
-    total_price: int
-    timestamp: datetime.datetime
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    waypoint_symbol: str = Field(alias="waypointSymbol")
+    ship_symbol: str = Field(alias="shipSymbol")
+    trade_symbol: str = Field(alias="tradeSymbol")
+    type: MarketTransactionType = Field(alias="type")
+    units: int = Field(alias="units")
+    price_per_unit: int = Field(alias="pricePerUnit")
+    total_price: int = Field(alias="totalPrice")
+    timestamp: datetime.datetime = Field(alias="timestamp")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        waypoint_symbol = self.waypoint_symbol
-        ship_symbol = self.ship_symbol
-        trade_symbol = self.trade_symbol
-        type = self.type.value
-
-        units = self.units
-        price_per_unit = self.price_per_unit
-        total_price = self.total_price
-        timestamp = self.timestamp.isoformat()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "waypointSymbol": waypoint_symbol,
-                "shipSymbol": ship_symbol,
-                "tradeSymbol": trade_symbol,
-                "type": type,
-                "units": units,
-                "pricePerUnit": price_per_unit,
-                "totalPrice": total_price,
-                "timestamp": timestamp,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        waypoint_symbol = d.pop("waypointSymbol")
-
-        ship_symbol = d.pop("shipSymbol")
-
-        trade_symbol = d.pop("tradeSymbol")
-
-        type = MarketTransactionType(d.pop("type"))
-
-        units = d.pop("units")
-
-        price_per_unit = d.pop("pricePerUnit")
-
-        total_price = d.pop("totalPrice")
-
-        timestamp = isoparse(d.pop("timestamp"))
-
-        market_transaction = cls(
-            waypoint_symbol=waypoint_symbol,
-            ship_symbol=ship_symbol,
-            trade_symbol=trade_symbol,
-            type=type,
-            units=units,
-            price_per_unit=price_per_unit,
-            total_price=total_price,
-            timestamp=timestamp,
-        )
-
-        market_transaction.additional_properties = d
-        return market_transaction
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/meta.py
+++ b/spacetraders/models/meta.py
@@ -12,14 +12,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="Meta")
 
 
-@attr.s(auto_attribs=True)
-class Meta:
+class Meta(BaseModel):
     """
     Attributes:
         total (int):
@@ -27,45 +27,13 @@ class Meta:
         limit (int):
     """
 
-    total: int
-    page: int
-    limit: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    total: int = Field(alias="total")
+    page: int = Field(alias="page")
+    limit: int = Field(alias="limit")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        total = self.total
-        page = self.page
-        limit = self.limit
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "total": total,
-                "page": page,
-                "limit": limit,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        total = d.pop("total")
-
-        page = d.pop("page")
-
-        limit = d.pop("limit")
-
-        meta = cls(
-            total=total,
-            page=page,
-            limit=limit,
-        )
-
-        meta.additional_properties = d
-        return meta
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/navigate_ship_json_body.py
+++ b/spacetraders/models/navigate_ship_json_body.py
@@ -12,46 +12,24 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="NavigateShipJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class NavigateShipJsonBody:
+class NavigateShipJsonBody(BaseModel):
     """
     Attributes:
         waypoint_symbol (str): The target destination.
     """
 
-    waypoint_symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    waypoint_symbol: str = Field(alias="waypointSymbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        waypoint_symbol = self.waypoint_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "waypointSymbol": waypoint_symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        waypoint_symbol = d.pop("waypointSymbol")
-
-        navigate_ship_json_body = cls(
-            waypoint_symbol=waypoint_symbol,
-        )
-
-        navigate_ship_json_body.additional_properties = d
-        return navigate_ship_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/navigate_ship_response_200.py
+++ b/spacetraders/models/navigate_ship_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.navigate_ship_response_200_data import NavigateShipResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.navigate_ship_response_200_data import NavigateShipResponse200Data
-
 
 T = TypeVar("T", bound="NavigateShipResponse200")
 
 
-@attr.s(auto_attribs=True)
-class NavigateShipResponse200:
+class NavigateShipResponse200(BaseModel):
     """
     Attributes:
         data (NavigateShipResponse200Data):
     """
 
-    data: "NavigateShipResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "NavigateShipResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.navigate_ship_response_200_data import NavigateShipResponse200Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.navigate_ship_response_200_data import NavigateShipResponse200Data
-
-        d = src_dict.copy()
-        data = NavigateShipResponse200Data.from_dict(d.pop("data"))
-
-        navigate_ship_response_200 = cls(
-            data=data,
-        )
-
-        navigate_ship_response_200.additional_properties = d
-        return navigate_ship_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/navigate_ship_response_200_data.py
+++ b/spacetraders/models/navigate_ship_response_200_data.py
@@ -13,19 +13,16 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_fuel import ShipFuel
+from ..models.ship_nav import ShipNav
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_fuel import ShipFuel
-    from ..models.ship_nav import ShipNav
-
 
 T = TypeVar("T", bound="NavigateShipResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class NavigateShipResponse200Data:
+class NavigateShipResponse200Data(BaseModel):
     """
     Attributes:
         fuel (ShipFuel): Details of the ship's fuel tanks including how much fuel was consumed during the last transit
@@ -33,46 +30,12 @@ class NavigateShipResponse200Data:
         nav (ShipNav): The navigation information of the ship.
     """
 
-    fuel: "ShipFuel"
-    nav: "ShipNav"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    fuel: "ShipFuel" = Field(alias="fuel")
+    nav: "ShipNav" = Field(alias="nav")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_fuel import ShipFuel
-        from ..models.ship_nav import ShipNav
-
-        fuel = self.fuel.to_dict()
-
-        nav = self.nav.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "fuel": fuel,
-                "nav": nav,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_fuel import ShipFuel
-        from ..models.ship_nav import ShipNav
-
-        d = src_dict.copy()
-        fuel = ShipFuel.from_dict(d.pop("fuel"))
-
-        nav = ShipNav.from_dict(d.pop("nav"))
-
-        navigate_ship_response_200_data = cls(
-            fuel=fuel,
-            nav=nav,
-        )
-
-        navigate_ship_response_200_data.additional_properties = d
-        return navigate_ship_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/orbit_ship_orbit_ship_200_response.py
+++ b/spacetraders/models/orbit_ship_orbit_ship_200_response.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.orbit_ship_orbit_ship_200_response_data import (
+    OrbitShipOrbitShip200ResponseData,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.orbit_ship_orbit_ship_200_response_data import (
-        OrbitShipOrbitShip200ResponseData,
-    )
-
 
 T = TypeVar("T", bound="OrbitShipOrbitShip200Response")
 
 
-@attr.s(auto_attribs=True)
-class OrbitShipOrbitShip200Response:
+class OrbitShipOrbitShip200Response(BaseModel):
     """
     Attributes:
         data (OrbitShipOrbitShip200ResponseData):
     """
 
-    data: "OrbitShipOrbitShip200ResponseData"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "OrbitShipOrbitShip200ResponseData" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.orbit_ship_orbit_ship_200_response_data import (
-            OrbitShipOrbitShip200ResponseData,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.orbit_ship_orbit_ship_200_response_data import (
-            OrbitShipOrbitShip200ResponseData,
-        )
-
-        d = src_dict.copy()
-        data = OrbitShipOrbitShip200ResponseData.from_dict(d.pop("data"))
-
-        orbit_ship_orbit_ship_200_response = cls(
-            data=data,
-        )
-
-        orbit_ship_orbit_ship_200_response.additional_properties = d
-        return orbit_ship_orbit_ship_200_response
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/orbit_ship_orbit_ship_200_response_data.py
+++ b/spacetraders/models/orbit_ship_orbit_ship_200_response_data.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_nav import ShipNav
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_nav import ShipNav
-
 
 T = TypeVar("T", bound="OrbitShipOrbitShip200ResponseData")
 
 
-@attr.s(auto_attribs=True)
-class OrbitShipOrbitShip200ResponseData:
+class OrbitShipOrbitShip200ResponseData(BaseModel):
     """
     Attributes:
         nav (ShipNav): The navigation information of the ship.
     """
 
-    nav: "ShipNav"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    nav: "ShipNav" = Field(alias="nav")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_nav import ShipNav
-
-        nav = self.nav.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "nav": nav,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_nav import ShipNav
-
-        d = src_dict.copy()
-        nav = ShipNav.from_dict(d.pop("nav"))
-
-        orbit_ship_orbit_ship_200_response_data = cls(
-            nav=nav,
-        )
-
-        orbit_ship_orbit_ship_200_response_data.additional_properties = d
-        return orbit_ship_orbit_ship_200_response_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/patch_ship_nav_json_body.py
+++ b/spacetraders/models/patch_ship_nav_json_body.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_nav_flight_mode import ShipNavFlightMode
 from ..types import UNSET, Unset
@@ -20,8 +21,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="PatchShipNavJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class PatchShipNavJsonBody:
+class PatchShipNavJsonBody(BaseModel):
     """
     Attributes:
         flight_mode (Union[Unset, ShipNavFlightMode]): The ship's set speed when traveling between waypoints or systems.
@@ -29,37 +29,10 @@ class PatchShipNavJsonBody:
     """
 
     flight_mode: Union[Unset, ShipNavFlightMode] = ShipNavFlightMode.CRUISE
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        flight_mode: Union[Unset, str] = UNSET
-        if not isinstance(self.flight_mode, Unset):
-            flight_mode = self.flight_mode.value
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if flight_mode is not UNSET:
-            field_dict["flightMode"] = flight_mode
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        _flight_mode = d.pop("flightMode", UNSET)
-        flight_mode: Union[Unset, ShipNavFlightMode]
-        if isinstance(_flight_mode, Unset):
-            flight_mode = UNSET
-        else:
-            flight_mode = ShipNavFlightMode(_flight_mode)
-
-        patch_ship_nav_json_body = cls(
-            flight_mode=flight_mode,
-        )
-
-        patch_ship_nav_json_body.additional_properties = d
-        return patch_ship_nav_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/patch_ship_nav_response_200.py
+++ b/spacetraders/models/patch_ship_nav_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_nav import ShipNav
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_nav import ShipNav
-
 
 T = TypeVar("T", bound="PatchShipNavResponse200")
 
 
-@attr.s(auto_attribs=True)
-class PatchShipNavResponse200:
+class PatchShipNavResponse200(BaseModel):
     """
     Attributes:
         data (ShipNav): The navigation information of the ship.
     """
 
-    data: "ShipNav"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "ShipNav" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_nav import ShipNav
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_nav import ShipNav
-
-        d = src_dict.copy()
-        data = ShipNav.from_dict(d.pop("data"))
-
-        patch_ship_nav_response_200 = cls(
-            data=data,
-        )
-
-        patch_ship_nav_response_200.additional_properties = d
-        return patch_ship_nav_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/purchase_cargo_purchase_cargo_201_response.py
+++ b/spacetraders/models/purchase_cargo_purchase_cargo_201_response.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.purchase_cargo_purchase_cargo_201_response_data import (
+    PurchaseCargoPurchaseCargo201ResponseData,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.purchase_cargo_purchase_cargo_201_response_data import (
-        PurchaseCargoPurchaseCargo201ResponseData,
-    )
-
 
 T = TypeVar("T", bound="PurchaseCargoPurchaseCargo201Response")
 
 
-@attr.s(auto_attribs=True)
-class PurchaseCargoPurchaseCargo201Response:
+class PurchaseCargoPurchaseCargo201Response(BaseModel):
     """
     Attributes:
         data (PurchaseCargoPurchaseCargo201ResponseData):
     """
 
-    data: "PurchaseCargoPurchaseCargo201ResponseData"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "PurchaseCargoPurchaseCargo201ResponseData" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.purchase_cargo_purchase_cargo_201_response_data import (
-            PurchaseCargoPurchaseCargo201ResponseData,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.purchase_cargo_purchase_cargo_201_response_data import (
-            PurchaseCargoPurchaseCargo201ResponseData,
-        )
-
-        d = src_dict.copy()
-        data = PurchaseCargoPurchaseCargo201ResponseData.from_dict(d.pop("data"))
-
-        purchase_cargo_purchase_cargo_201_response = cls(
-            data=data,
-        )
-
-        purchase_cargo_purchase_cargo_201_response.additional_properties = d
-        return purchase_cargo_purchase_cargo_201_response
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/purchase_cargo_purchase_cargo_201_response_data.py
+++ b/spacetraders/models/purchase_cargo_purchase_cargo_201_response_data.py
@@ -13,20 +13,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
+from ..models.market_transaction import MarketTransaction
+from ..models.ship_cargo import ShipCargo
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-    from ..models.market_transaction import MarketTransaction
-    from ..models.ship_cargo import ShipCargo
-
 
 T = TypeVar("T", bound="PurchaseCargoPurchaseCargo201ResponseData")
 
 
-@attr.s(auto_attribs=True)
-class PurchaseCargoPurchaseCargo201ResponseData:
+class PurchaseCargoPurchaseCargo201ResponseData(BaseModel):
     """
     Attributes:
         agent (Agent):
@@ -34,55 +31,13 @@ class PurchaseCargoPurchaseCargo201ResponseData:
         transaction (MarketTransaction):
     """
 
-    agent: "Agent"
-    cargo: "ShipCargo"
-    transaction: "MarketTransaction"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    agent: "Agent" = Field(alias="agent")
+    cargo: "ShipCargo" = Field(alias="cargo")
+    transaction: "MarketTransaction" = Field(alias="transaction")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-        from ..models.market_transaction import MarketTransaction
-        from ..models.ship_cargo import ShipCargo
-
-        agent = self.agent.to_dict()
-
-        cargo = self.cargo.to_dict()
-
-        transaction = self.transaction.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "agent": agent,
-                "cargo": cargo,
-                "transaction": transaction,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-        from ..models.market_transaction import MarketTransaction
-        from ..models.ship_cargo import ShipCargo
-
-        d = src_dict.copy()
-        agent = Agent.from_dict(d.pop("agent"))
-
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        transaction = MarketTransaction.from_dict(d.pop("transaction"))
-
-        purchase_cargo_purchase_cargo_201_response_data = cls(
-            agent=agent,
-            cargo=cargo,
-            transaction=transaction,
-        )
-
-        purchase_cargo_purchase_cargo_201_response_data.additional_properties = d
-        return purchase_cargo_purchase_cargo_201_response_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/purchase_cargo_purchase_cargo_request.py
+++ b/spacetraders/models/purchase_cargo_purchase_cargo_request.py
@@ -12,53 +12,26 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="PurchaseCargoPurchaseCargoRequest")
 
 
-@attr.s(auto_attribs=True)
-class PurchaseCargoPurchaseCargoRequest:
+class PurchaseCargoPurchaseCargoRequest(BaseModel):
     """
     Attributes:
         symbol (str):
         units (int):
     """
 
-    symbol: str
-    units: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    units: int = Field(alias="units")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "units": units,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        units = d.pop("units")
-
-        purchase_cargo_purchase_cargo_request = cls(
-            symbol=symbol,
-            units=units,
-        )
-
-        purchase_cargo_purchase_cargo_request.additional_properties = d
-        return purchase_cargo_purchase_cargo_request
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/purchase_ship_json_body.py
+++ b/spacetraders/models/purchase_ship_json_body.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_type import ShipType
 from ..types import UNSET, Unset
@@ -19,48 +20,19 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="PurchaseShipJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class PurchaseShipJsonBody:
+class PurchaseShipJsonBody(BaseModel):
     """
     Attributes:
         ship_type (ShipType):
         waypoint_symbol (str): The symbol of the waypoint you want to purchase the ship at.
     """
 
-    ship_type: ShipType
-    waypoint_symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    ship_type: ShipType = Field(alias="shipType")
+    waypoint_symbol: str = Field(alias="waypointSymbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        ship_type = self.ship_type.value
-
-        waypoint_symbol = self.waypoint_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "shipType": ship_type,
-                "waypointSymbol": waypoint_symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        ship_type = ShipType(d.pop("shipType"))
-
-        waypoint_symbol = d.pop("waypointSymbol")
-
-        purchase_ship_json_body = cls(
-            ship_type=ship_type,
-            waypoint_symbol=waypoint_symbol,
-        )
-
-        purchase_ship_json_body.additional_properties = d
-        return purchase_ship_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/purchase_ship_response_201.py
+++ b/spacetraders/models/purchase_ship_response_201.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.purchase_ship_response_201_data import PurchaseShipResponse201Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.purchase_ship_response_201_data import PurchaseShipResponse201Data
-
 
 T = TypeVar("T", bound="PurchaseShipResponse201")
 
 
-@attr.s(auto_attribs=True)
-class PurchaseShipResponse201:
+class PurchaseShipResponse201(BaseModel):
     """
     Attributes:
         data (PurchaseShipResponse201Data):
     """
 
-    data: "PurchaseShipResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "PurchaseShipResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.purchase_ship_response_201_data import PurchaseShipResponse201Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.purchase_ship_response_201_data import PurchaseShipResponse201Data
-
-        d = src_dict.copy()
-        data = PurchaseShipResponse201Data.from_dict(d.pop("data"))
-
-        purchase_ship_response_201 = cls(
-            data=data,
-        )
-
-        purchase_ship_response_201.additional_properties = d
-        return purchase_ship_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/purchase_ship_response_201_data.py
+++ b/spacetraders/models/purchase_ship_response_201_data.py
@@ -13,20 +13,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
+from ..models.ship import Ship
+from ..models.shipyard_transaction import ShipyardTransaction
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-    from ..models.ship import Ship
-    from ..models.shipyard_transaction import ShipyardTransaction
-
 
 T = TypeVar("T", bound="PurchaseShipResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class PurchaseShipResponse201Data:
+class PurchaseShipResponse201Data(BaseModel):
     """
     Attributes:
         agent (Agent):
@@ -34,55 +31,13 @@ class PurchaseShipResponse201Data:
         transaction (ShipyardTransaction):
     """
 
-    agent: "Agent"
-    ship: "Ship"
-    transaction: "ShipyardTransaction"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    agent: "Agent" = Field(alias="agent")
+    ship: "Ship" = Field(alias="ship")
+    transaction: "ShipyardTransaction" = Field(alias="transaction")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-        from ..models.ship import Ship
-        from ..models.shipyard_transaction import ShipyardTransaction
-
-        agent = self.agent.to_dict()
-
-        ship = self.ship.to_dict()
-
-        transaction = self.transaction.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "agent": agent,
-                "ship": ship,
-                "transaction": transaction,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-        from ..models.ship import Ship
-        from ..models.shipyard_transaction import ShipyardTransaction
-
-        d = src_dict.copy()
-        agent = Agent.from_dict(d.pop("agent"))
-
-        ship = Ship.from_dict(d.pop("ship"))
-
-        transaction = ShipyardTransaction.from_dict(d.pop("transaction"))
-
-        purchase_ship_response_201_data = cls(
-            agent=agent,
-            ship=ship,
-            transaction=transaction,
-        )
-
-        purchase_ship_response_201_data.additional_properties = d
-        return purchase_ship_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/refuel_ship_response_200.py
+++ b/spacetraders/models/refuel_ship_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.refuel_ship_response_200_data import RefuelShipResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.refuel_ship_response_200_data import RefuelShipResponse200Data
-
 
 T = TypeVar("T", bound="RefuelShipResponse200")
 
 
-@attr.s(auto_attribs=True)
-class RefuelShipResponse200:
+class RefuelShipResponse200(BaseModel):
     """
     Attributes:
         data (RefuelShipResponse200Data):
     """
 
-    data: "RefuelShipResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "RefuelShipResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.refuel_ship_response_200_data import RefuelShipResponse200Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.refuel_ship_response_200_data import RefuelShipResponse200Data
-
-        d = src_dict.copy()
-        data = RefuelShipResponse200Data.from_dict(d.pop("data"))
-
-        refuel_ship_response_200 = cls(
-            data=data,
-        )
-
-        refuel_ship_response_200.additional_properties = d
-        return refuel_ship_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/refuel_ship_response_200_data.py
+++ b/spacetraders/models/refuel_ship_response_200_data.py
@@ -13,19 +13,16 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
+from ..models.ship_fuel import ShipFuel
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-    from ..models.ship_fuel import ShipFuel
-
 
 T = TypeVar("T", bound="RefuelShipResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class RefuelShipResponse200Data:
+class RefuelShipResponse200Data(BaseModel):
     """
     Attributes:
         agent (Agent):
@@ -33,46 +30,12 @@ class RefuelShipResponse200Data:
             or action.
     """
 
-    agent: "Agent"
-    fuel: "ShipFuel"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    agent: "Agent" = Field(alias="agent")
+    fuel: "ShipFuel" = Field(alias="fuel")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-        from ..models.ship_fuel import ShipFuel
-
-        agent = self.agent.to_dict()
-
-        fuel = self.fuel.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "agent": agent,
-                "fuel": fuel,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-        from ..models.ship_fuel import ShipFuel
-
-        d = src_dict.copy()
-        agent = Agent.from_dict(d.pop("agent"))
-
-        fuel = ShipFuel.from_dict(d.pop("fuel"))
-
-        refuel_ship_response_200_data = cls(
-            agent=agent,
-            fuel=fuel,
-        )
-
-        refuel_ship_response_200_data.additional_properties = d
-        return refuel_ship_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/register_json_body.py
+++ b/spacetraders/models/register_json_body.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.register_json_body_faction import RegisterJsonBodyFaction
 from ..types import UNSET, Unset
@@ -19,48 +20,19 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="RegisterJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class RegisterJsonBody:
+class RegisterJsonBody(BaseModel):
     """
     Attributes:
         faction (RegisterJsonBodyFaction): The faction you choose determines your headquarters.
         symbol (str): How other agents will see your ships and information. Example: BADGER.
     """
 
-    faction: RegisterJsonBodyFaction
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    faction: RegisterJsonBodyFaction = Field(alias="faction")
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        faction = self.faction.value
-
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "faction": faction,
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        faction = RegisterJsonBodyFaction(d.pop("faction"))
-
-        symbol = d.pop("symbol")
-
-        register_json_body = cls(
-            faction=faction,
-            symbol=symbol,
-        )
-
-        register_json_body.additional_properties = d
-        return register_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/register_response_201.py
+++ b/spacetraders/models/register_response_201.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.register_response_201_data import RegisterResponse201Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.register_response_201_data import RegisterResponse201Data
-
 
 T = TypeVar("T", bound="RegisterResponse201")
 
 
-@attr.s(auto_attribs=True)
-class RegisterResponse201:
+class RegisterResponse201(BaseModel):
     """
     Attributes:
         data (RegisterResponse201Data):
     """
 
-    data: "RegisterResponse201Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "RegisterResponse201Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.register_response_201_data import RegisterResponse201Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.register_response_201_data import RegisterResponse201Data
-
-        d = src_dict.copy()
-        data = RegisterResponse201Data.from_dict(d.pop("data"))
-
-        register_response_201 = cls(
-            data=data,
-        )
-
-        register_response_201.additional_properties = d
-        return register_response_201
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/register_response_201_data.py
+++ b/spacetraders/models/register_response_201_data.py
@@ -13,21 +13,18 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
+from ..models.contract import Contract
+from ..models.faction import Faction
+from ..models.ship import Ship
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-    from ..models.contract import Contract
-    from ..models.faction import Faction
-    from ..models.ship import Ship
-
 
 T = TypeVar("T", bound="RegisterResponse201Data")
 
 
-@attr.s(auto_attribs=True)
-class RegisterResponse201Data:
+class RegisterResponse201Data(BaseModel):
     """
     Attributes:
         agent (Agent):
@@ -37,71 +34,15 @@ class RegisterResponse201Data:
         token (str): A Bearer token for accessing secured API endpoints.
     """
 
-    agent: "Agent"
-    contract: "Contract"
-    faction: "Faction"
-    ship: "Ship"
-    token: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    agent: "Agent" = Field(alias="agent")
+    contract: "Contract" = Field(alias="contract")
+    faction: "Faction" = Field(alias="faction")
+    ship: "Ship" = Field(alias="ship")
+    token: str = Field(alias="token")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-        from ..models.contract import Contract
-        from ..models.faction import Faction
-        from ..models.ship import Ship
-
-        agent = self.agent.to_dict()
-
-        contract = self.contract.to_dict()
-
-        faction = self.faction.to_dict()
-
-        ship = self.ship.to_dict()
-
-        token = self.token
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "agent": agent,
-                "contract": contract,
-                "faction": faction,
-                "ship": ship,
-                "token": token,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-        from ..models.contract import Contract
-        from ..models.faction import Faction
-        from ..models.ship import Ship
-
-        d = src_dict.copy()
-        agent = Agent.from_dict(d.pop("agent"))
-
-        contract = Contract.from_dict(d.pop("contract"))
-
-        faction = Faction.from_dict(d.pop("faction"))
-
-        ship = Ship.from_dict(d.pop("ship"))
-
-        token = d.pop("token")
-
-        register_response_201_data = cls(
-            agent=agent,
-            contract=contract,
-            faction=faction,
-            ship=ship,
-            token=token,
-        )
-
-        register_response_201_data.additional_properties = d
-        return register_response_201_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/scanned_ship.py
+++ b/spacetraders/models/scanned_ship.py
@@ -14,23 +14,20 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.scanned_ship_engine import ScannedShipEngine
+from ..models.scanned_ship_frame import ScannedShipFrame
+from ..models.scanned_ship_mounts_item import ScannedShipMountsItem
+from ..models.scanned_ship_reactor import ScannedShipReactor
+from ..models.ship_nav import ShipNav
+from ..models.ship_registration import ShipRegistration
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.scanned_ship_engine import ScannedShipEngine
-    from ..models.scanned_ship_frame import ScannedShipFrame
-    from ..models.scanned_ship_mounts_item import ScannedShipMountsItem
-    from ..models.scanned_ship_reactor import ScannedShipReactor
-    from ..models.ship_nav import ShipNav
-    from ..models.ship_registration import ShipRegistration
-
 
 T = TypeVar("T", bound="ScannedShip")
 
 
-@attr.s(auto_attribs=True)
-class ScannedShip:
+class ScannedShip(BaseModel):
     """The ship that was scanned. Details include information about the ship that could be detected by the scanner.
 
     Attributes:
@@ -43,116 +40,17 @@ class ScannedShip:
         mounts (Union[Unset, List['ScannedShipMountsItem']]):
     """
 
-    symbol: str
-    registration: "ShipRegistration"
-    nav: "ShipNav"
-    engine: "ScannedShipEngine"
+    symbol: str = Field(alias="symbol")
+    registration: "ShipRegistration" = Field(alias="registration")
+    nav: "ShipNav" = Field(alias="nav")
+    engine: "ScannedShipEngine" = Field(alias="engine")
     frame: Union[Unset, "ScannedShipFrame"] = UNSET
     reactor: Union[Unset, "ScannedShipReactor"] = UNSET
     mounts: Union[Unset, List["ScannedShipMountsItem"]] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.scanned_ship_engine import ScannedShipEngine
-        from ..models.scanned_ship_frame import ScannedShipFrame
-        from ..models.scanned_ship_mounts_item import ScannedShipMountsItem
-        from ..models.scanned_ship_reactor import ScannedShipReactor
-        from ..models.ship_nav import ShipNav
-        from ..models.ship_registration import ShipRegistration
-
-        symbol = self.symbol
-        registration = self.registration.to_dict()
-
-        nav = self.nav.to_dict()
-
-        engine = self.engine.to_dict()
-
-        frame: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.frame, Unset):
-            frame = self.frame.to_dict()
-
-        reactor: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.reactor, Unset):
-            reactor = self.reactor.to_dict()
-
-        mounts: Union[Unset, List[Dict[str, Any]]] = UNSET
-        if not isinstance(self.mounts, Unset):
-            mounts = []
-            for mounts_item_data in self.mounts:
-                mounts_item = mounts_item_data.to_dict()
-
-                mounts.append(mounts_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "registration": registration,
-                "nav": nav,
-                "engine": engine,
-            }
-        )
-        if frame is not UNSET:
-            field_dict["frame"] = frame
-        if reactor is not UNSET:
-            field_dict["reactor"] = reactor
-        if mounts is not UNSET:
-            field_dict["mounts"] = mounts
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.scanned_ship_engine import ScannedShipEngine
-        from ..models.scanned_ship_frame import ScannedShipFrame
-        from ..models.scanned_ship_mounts_item import ScannedShipMountsItem
-        from ..models.scanned_ship_reactor import ScannedShipReactor
-        from ..models.ship_nav import ShipNav
-        from ..models.ship_registration import ShipRegistration
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        registration = ShipRegistration.from_dict(d.pop("registration"))
-
-        nav = ShipNav.from_dict(d.pop("nav"))
-
-        engine = ScannedShipEngine.from_dict(d.pop("engine"))
-
-        _frame = d.pop("frame", UNSET)
-        frame: Union[Unset, ScannedShipFrame]
-        if isinstance(_frame, Unset):
-            frame = UNSET
-        else:
-            frame = ScannedShipFrame.from_dict(_frame)
-
-        _reactor = d.pop("reactor", UNSET)
-        reactor: Union[Unset, ScannedShipReactor]
-        if isinstance(_reactor, Unset):
-            reactor = UNSET
-        else:
-            reactor = ScannedShipReactor.from_dict(_reactor)
-
-        mounts = []
-        _mounts = d.pop("mounts", UNSET)
-        for mounts_item_data in _mounts or []:
-            mounts_item = ScannedShipMountsItem.from_dict(mounts_item_data)
-
-            mounts.append(mounts_item)
-
-        scanned_ship = cls(
-            symbol=symbol,
-            registration=registration,
-            nav=nav,
-            engine=engine,
-            frame=frame,
-            reactor=reactor,
-            mounts=mounts,
-        )
-
-        scanned_ship.additional_properties = d
-        return scanned_ship
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/scanned_ship_engine.py
+++ b/spacetraders/models/scanned_ship_engine.py
@@ -12,47 +12,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ScannedShipEngine")
 
 
-@attr.s(auto_attribs=True)
-class ScannedShipEngine:
+class ScannedShipEngine(BaseModel):
     """The engine of the ship.
 
     Attributes:
         symbol (str):
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        scanned_ship_engine = cls(
-            symbol=symbol,
-        )
-
-        scanned_ship_engine.additional_properties = d
-        return scanned_ship_engine
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/scanned_ship_frame.py
+++ b/spacetraders/models/scanned_ship_frame.py
@@ -12,47 +12,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ScannedShipFrame")
 
 
-@attr.s(auto_attribs=True)
-class ScannedShipFrame:
+class ScannedShipFrame(BaseModel):
     """The frame of the ship.
 
     Attributes:
         symbol (str):
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        scanned_ship_frame = cls(
-            symbol=symbol,
-        )
-
-        scanned_ship_frame.additional_properties = d
-        return scanned_ship_frame
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/scanned_ship_mounts_item.py
+++ b/spacetraders/models/scanned_ship_mounts_item.py
@@ -12,47 +12,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ScannedShipMountsItem")
 
 
-@attr.s(auto_attribs=True)
-class ScannedShipMountsItem:
+class ScannedShipMountsItem(BaseModel):
     """A mount on the ship.
 
     Attributes:
         symbol (str):
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        scanned_ship_mounts_item = cls(
-            symbol=symbol,
-        )
-
-        scanned_ship_mounts_item.additional_properties = d
-        return scanned_ship_mounts_item
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/scanned_ship_reactor.py
+++ b/spacetraders/models/scanned_ship_reactor.py
@@ -12,47 +12,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ScannedShipReactor")
 
 
-@attr.s(auto_attribs=True)
-class ScannedShipReactor:
+class ScannedShipReactor(BaseModel):
     """The reactor of the ship.
 
     Attributes:
         symbol (str):
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        scanned_ship_reactor = cls(
-            symbol=symbol,
-        )
-
-        scanned_ship_reactor.additional_properties = d
-        return scanned_ship_reactor
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/scanned_system.py
+++ b/spacetraders/models/scanned_system.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.system_type import SystemType
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="ScannedSystem")
 
 
-@attr.s(auto_attribs=True)
-class ScannedSystem:
+class ScannedSystem(BaseModel):
     """
     Attributes:
         symbol (str):
@@ -31,64 +31,16 @@ class ScannedSystem:
         distance (int):
     """
 
-    symbol: str
-    sector_symbol: str
-    type: SystemType
-    x: int
-    y: int
-    distance: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    sector_symbol: str = Field(alias="sectorSymbol")
+    type: SystemType = Field(alias="type")
+    x: int = Field(alias="x")
+    y: int = Field(alias="y")
+    distance: int = Field(alias="distance")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        sector_symbol = self.sector_symbol
-        type = self.type.value
-
-        x = self.x
-        y = self.y
-        distance = self.distance
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "sectorSymbol": sector_symbol,
-                "type": type,
-                "x": x,
-                "y": y,
-                "distance": distance,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        sector_symbol = d.pop("sectorSymbol")
-
-        type = SystemType(d.pop("type"))
-
-        x = d.pop("x")
-
-        y = d.pop("y")
-
-        distance = d.pop("distance")
-
-        scanned_system = cls(
-            symbol=symbol,
-            sector_symbol=sector_symbol,
-            type=type,
-            x=x,
-            y=y,
-            distance=distance,
-        )
-
-        scanned_system.additional_properties = d
-        return scanned_system
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/scanned_waypoint.py
+++ b/spacetraders/models/scanned_waypoint.py
@@ -14,22 +14,19 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.chart import Chart
+from ..models.waypoint_faction import WaypointFaction
+from ..models.waypoint_orbital import WaypointOrbital
+from ..models.waypoint_trait import WaypointTrait
 from ..models.waypoint_type import WaypointType
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.chart import Chart
-    from ..models.waypoint_faction import WaypointFaction
-    from ..models.waypoint_orbital import WaypointOrbital
-    from ..models.waypoint_trait import WaypointTrait
-
 
 T = TypeVar("T", bound="ScannedWaypoint")
 
 
-@attr.s(auto_attribs=True)
-class ScannedWaypoint:
+class ScannedWaypoint(BaseModel):
     """A waypoint is a location that ships can travel to such as a Planet, Moon or Space Station.
 
     Attributes:
@@ -45,129 +42,19 @@ class ScannedWaypoint:
             agents.
     """
 
-    symbol: str
-    type: WaypointType
-    system_symbol: str
-    x: int
-    y: int
-    orbitals: List["WaypointOrbital"]
-    traits: List["WaypointTrait"]
+    symbol: str = Field(alias="symbol")
+    type: WaypointType = Field(alias="type")
+    system_symbol: str = Field(alias="systemSymbol")
+    x: int = Field(alias="x")
+    y: int = Field(alias="y")
+    orbitals: List["WaypointOrbital"] = Field(alias="orbitals")
+    traits: List["WaypointTrait"] = Field(alias="traits")
     faction: Union[Unset, "WaypointFaction"] = UNSET
     chart: Union[Unset, "Chart"] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.chart import Chart
-        from ..models.waypoint_faction import WaypointFaction
-        from ..models.waypoint_orbital import WaypointOrbital
-        from ..models.waypoint_trait import WaypointTrait
-
-        symbol = self.symbol
-        type = self.type.value
-
-        system_symbol = self.system_symbol
-        x = self.x
-        y = self.y
-        orbitals = []
-        for orbitals_item_data in self.orbitals:
-            orbitals_item = orbitals_item_data.to_dict()
-
-            orbitals.append(orbitals_item)
-
-        traits = []
-        for traits_item_data in self.traits:
-            traits_item = traits_item_data.to_dict()
-
-            traits.append(traits_item)
-
-        faction: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.faction, Unset):
-            faction = self.faction.to_dict()
-
-        chart: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.chart, Unset):
-            chart = self.chart.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "type": type,
-                "systemSymbol": system_symbol,
-                "x": x,
-                "y": y,
-                "orbitals": orbitals,
-                "traits": traits,
-            }
-        )
-        if faction is not UNSET:
-            field_dict["faction"] = faction
-        if chart is not UNSET:
-            field_dict["chart"] = chart
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.chart import Chart
-        from ..models.waypoint_faction import WaypointFaction
-        from ..models.waypoint_orbital import WaypointOrbital
-        from ..models.waypoint_trait import WaypointTrait
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        type = WaypointType(d.pop("type"))
-
-        system_symbol = d.pop("systemSymbol")
-
-        x = d.pop("x")
-
-        y = d.pop("y")
-
-        orbitals = []
-        _orbitals = d.pop("orbitals")
-        for orbitals_item_data in _orbitals:
-            orbitals_item = WaypointOrbital.from_dict(orbitals_item_data)
-
-            orbitals.append(orbitals_item)
-
-        traits = []
-        _traits = d.pop("traits")
-        for traits_item_data in _traits:
-            traits_item = WaypointTrait.from_dict(traits_item_data)
-
-            traits.append(traits_item)
-
-        _faction = d.pop("faction", UNSET)
-        faction: Union[Unset, WaypointFaction]
-        if isinstance(_faction, Unset):
-            faction = UNSET
-        else:
-            faction = WaypointFaction.from_dict(_faction)
-
-        _chart = d.pop("chart", UNSET)
-        chart: Union[Unset, Chart]
-        if isinstance(_chart, Unset):
-            chart = UNSET
-        else:
-            chart = Chart.from_dict(_chart)
-
-        scanned_waypoint = cls(
-            symbol=symbol,
-            type=type,
-            system_symbol=system_symbol,
-            x=x,
-            y=y,
-            orbitals=orbitals,
-            traits=traits,
-            faction=faction,
-            chart=chart,
-        )
-
-        scanned_waypoint.additional_properties = d
-        return scanned_waypoint
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/sell_cargo_sell_cargo_201_response.py
+++ b/spacetraders/models/sell_cargo_sell_cargo_201_response.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.sell_cargo_sell_cargo_201_response_data import (
+    SellCargoSellCargo201ResponseData,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.sell_cargo_sell_cargo_201_response_data import (
-        SellCargoSellCargo201ResponseData,
-    )
-
 
 T = TypeVar("T", bound="SellCargoSellCargo201Response")
 
 
-@attr.s(auto_attribs=True)
-class SellCargoSellCargo201Response:
+class SellCargoSellCargo201Response(BaseModel):
     """
     Attributes:
         data (SellCargoSellCargo201ResponseData):
     """
 
-    data: "SellCargoSellCargo201ResponseData"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "SellCargoSellCargo201ResponseData" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.sell_cargo_sell_cargo_201_response_data import (
-            SellCargoSellCargo201ResponseData,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.sell_cargo_sell_cargo_201_response_data import (
-            SellCargoSellCargo201ResponseData,
-        )
-
-        d = src_dict.copy()
-        data = SellCargoSellCargo201ResponseData.from_dict(d.pop("data"))
-
-        sell_cargo_sell_cargo_201_response = cls(
-            data=data,
-        )
-
-        sell_cargo_sell_cargo_201_response.additional_properties = d
-        return sell_cargo_sell_cargo_201_response
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/sell_cargo_sell_cargo_201_response_data.py
+++ b/spacetraders/models/sell_cargo_sell_cargo_201_response_data.py
@@ -13,20 +13,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.agent import Agent
+from ..models.market_transaction import MarketTransaction
+from ..models.ship_cargo import ShipCargo
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.agent import Agent
-    from ..models.market_transaction import MarketTransaction
-    from ..models.ship_cargo import ShipCargo
-
 
 T = TypeVar("T", bound="SellCargoSellCargo201ResponseData")
 
 
-@attr.s(auto_attribs=True)
-class SellCargoSellCargo201ResponseData:
+class SellCargoSellCargo201ResponseData(BaseModel):
     """
     Attributes:
         agent (Agent):
@@ -34,55 +31,13 @@ class SellCargoSellCargo201ResponseData:
         transaction (MarketTransaction):
     """
 
-    agent: "Agent"
-    cargo: "ShipCargo"
-    transaction: "MarketTransaction"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    agent: "Agent" = Field(alias="agent")
+    cargo: "ShipCargo" = Field(alias="cargo")
+    transaction: "MarketTransaction" = Field(alias="transaction")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.agent import Agent
-        from ..models.market_transaction import MarketTransaction
-        from ..models.ship_cargo import ShipCargo
-
-        agent = self.agent.to_dict()
-
-        cargo = self.cargo.to_dict()
-
-        transaction = self.transaction.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "agent": agent,
-                "cargo": cargo,
-                "transaction": transaction,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.agent import Agent
-        from ..models.market_transaction import MarketTransaction
-        from ..models.ship_cargo import ShipCargo
-
-        d = src_dict.copy()
-        agent = Agent.from_dict(d.pop("agent"))
-
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        transaction = MarketTransaction.from_dict(d.pop("transaction"))
-
-        sell_cargo_sell_cargo_201_response_data = cls(
-            agent=agent,
-            cargo=cargo,
-            transaction=transaction,
-        )
-
-        sell_cargo_sell_cargo_201_response_data.additional_properties = d
-        return sell_cargo_sell_cargo_201_response_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/sell_cargo_sell_cargo_request.py
+++ b/spacetraders/models/sell_cargo_sell_cargo_request.py
@@ -12,53 +12,26 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="SellCargoSellCargoRequest")
 
 
-@attr.s(auto_attribs=True)
-class SellCargoSellCargoRequest:
+class SellCargoSellCargoRequest(BaseModel):
     """
     Attributes:
         symbol (str):
         units (int):
     """
 
-    symbol: str
-    units: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    units: int = Field(alias="units")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "units": units,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        units = d.pop("units")
-
-        sell_cargo_sell_cargo_request = cls(
-            symbol=symbol,
-            units=units,
-        )
-
-        sell_cargo_sell_cargo_request.additional_properties = d
-        return sell_cargo_sell_cargo_request
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship.py
+++ b/spacetraders/models/ship.py
@@ -13,27 +13,24 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_cargo import ShipCargo
+from ..models.ship_crew import ShipCrew
+from ..models.ship_engine import ShipEngine
+from ..models.ship_frame import ShipFrame
+from ..models.ship_fuel import ShipFuel
+from ..models.ship_module import ShipModule
+from ..models.ship_mount import ShipMount
+from ..models.ship_nav import ShipNav
+from ..models.ship_reactor import ShipReactor
+from ..models.ship_registration import ShipRegistration
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_cargo import ShipCargo
-    from ..models.ship_crew import ShipCrew
-    from ..models.ship_engine import ShipEngine
-    from ..models.ship_frame import ShipFrame
-    from ..models.ship_fuel import ShipFuel
-    from ..models.ship_module import ShipModule
-    from ..models.ship_mount import ShipMount
-    from ..models.ship_nav import ShipNav
-    from ..models.ship_reactor import ShipReactor
-    from ..models.ship_registration import ShipRegistration
-
 
 T = TypeVar("T", bound="Ship")
 
 
-@attr.s(auto_attribs=True)
-class Ship:
+class Ship(BaseModel):
     """A ship
 
     Attributes:
@@ -54,142 +51,21 @@ class Ship:
             or action.
     """
 
-    symbol: str
-    registration: "ShipRegistration"
-    nav: "ShipNav"
-    crew: "ShipCrew"
-    frame: "ShipFrame"
-    reactor: "ShipReactor"
-    engine: "ShipEngine"
-    modules: List["ShipModule"]
-    mounts: List["ShipMount"]
-    cargo: "ShipCargo"
-    fuel: "ShipFuel"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    registration: "ShipRegistration" = Field(alias="registration")
+    nav: "ShipNav" = Field(alias="nav")
+    crew: "ShipCrew" = Field(alias="crew")
+    frame: "ShipFrame" = Field(alias="frame")
+    reactor: "ShipReactor" = Field(alias="reactor")
+    engine: "ShipEngine" = Field(alias="engine")
+    modules: List["ShipModule"] = Field(alias="modules")
+    mounts: List["ShipMount"] = Field(alias="mounts")
+    cargo: "ShipCargo" = Field(alias="cargo")
+    fuel: "ShipFuel" = Field(alias="fuel")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_cargo import ShipCargo
-        from ..models.ship_crew import ShipCrew
-        from ..models.ship_engine import ShipEngine
-        from ..models.ship_frame import ShipFrame
-        from ..models.ship_fuel import ShipFuel
-        from ..models.ship_module import ShipModule
-        from ..models.ship_mount import ShipMount
-        from ..models.ship_nav import ShipNav
-        from ..models.ship_reactor import ShipReactor
-        from ..models.ship_registration import ShipRegistration
-
-        symbol = self.symbol
-        registration = self.registration.to_dict()
-
-        nav = self.nav.to_dict()
-
-        crew = self.crew.to_dict()
-
-        frame = self.frame.to_dict()
-
-        reactor = self.reactor.to_dict()
-
-        engine = self.engine.to_dict()
-
-        modules = []
-        for modules_item_data in self.modules:
-            modules_item = modules_item_data.to_dict()
-
-            modules.append(modules_item)
-
-        mounts = []
-        for mounts_item_data in self.mounts:
-            mounts_item = mounts_item_data.to_dict()
-
-            mounts.append(mounts_item)
-
-        cargo = self.cargo.to_dict()
-
-        fuel = self.fuel.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "registration": registration,
-                "nav": nav,
-                "crew": crew,
-                "frame": frame,
-                "reactor": reactor,
-                "engine": engine,
-                "modules": modules,
-                "mounts": mounts,
-                "cargo": cargo,
-                "fuel": fuel,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_cargo import ShipCargo
-        from ..models.ship_crew import ShipCrew
-        from ..models.ship_engine import ShipEngine
-        from ..models.ship_frame import ShipFrame
-        from ..models.ship_fuel import ShipFuel
-        from ..models.ship_module import ShipModule
-        from ..models.ship_mount import ShipMount
-        from ..models.ship_nav import ShipNav
-        from ..models.ship_reactor import ShipReactor
-        from ..models.ship_registration import ShipRegistration
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        registration = ShipRegistration.from_dict(d.pop("registration"))
-
-        nav = ShipNav.from_dict(d.pop("nav"))
-
-        crew = ShipCrew.from_dict(d.pop("crew"))
-
-        frame = ShipFrame.from_dict(d.pop("frame"))
-
-        reactor = ShipReactor.from_dict(d.pop("reactor"))
-
-        engine = ShipEngine.from_dict(d.pop("engine"))
-
-        modules = []
-        _modules = d.pop("modules")
-        for modules_item_data in _modules:
-            modules_item = ShipModule.from_dict(modules_item_data)
-
-            modules.append(modules_item)
-
-        mounts = []
-        _mounts = d.pop("mounts")
-        for mounts_item_data in _mounts:
-            mounts_item = ShipMount.from_dict(mounts_item_data)
-
-            mounts.append(mounts_item)
-
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        fuel = ShipFuel.from_dict(d.pop("fuel"))
-
-        ship = cls(
-            symbol=symbol,
-            registration=registration,
-            nav=nav,
-            crew=crew,
-            frame=frame,
-            reactor=reactor,
-            engine=engine,
-            modules=modules,
-            mounts=mounts,
-            cargo=cargo,
-            fuel=fuel,
-        )
-
-        ship.additional_properties = d
-        return ship
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_cargo.py
+++ b/spacetraders/models/ship_cargo.py
@@ -13,18 +13,15 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_cargo_item import ShipCargoItem
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_cargo_item import ShipCargoItem
-
 
 T = TypeVar("T", bound="ShipCargo")
 
 
-@attr.s(auto_attribs=True)
-class ShipCargo:
+class ShipCargo(BaseModel):
     """
     Attributes:
         capacity (int): The max number of items that can be stored in the cargo hold.
@@ -32,58 +29,13 @@ class ShipCargo:
         inventory (List['ShipCargoItem']): The items currently in the cargo hold.
     """
 
-    capacity: int
-    units: int
-    inventory: List["ShipCargoItem"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    capacity: int = Field(alias="capacity")
+    units: int = Field(alias="units")
+    inventory: List["ShipCargoItem"] = Field(alias="inventory")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_cargo_item import ShipCargoItem
-
-        capacity = self.capacity
-        units = self.units
-        inventory = []
-        for inventory_item_data in self.inventory:
-            inventory_item = inventory_item_data.to_dict()
-
-            inventory.append(inventory_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "capacity": capacity,
-                "units": units,
-                "inventory": inventory,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_cargo_item import ShipCargoItem
-
-        d = src_dict.copy()
-        capacity = d.pop("capacity")
-
-        units = d.pop("units")
-
-        inventory = []
-        _inventory = d.pop("inventory")
-        for inventory_item_data in _inventory:
-            inventory_item = ShipCargoItem.from_dict(inventory_item_data)
-
-            inventory.append(inventory_item)
-
-        ship_cargo = cls(
-            capacity=capacity,
-            units=units,
-            inventory=inventory,
-        )
-
-        ship_cargo.additional_properties = d
-        return ship_cargo
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_cargo_item.py
+++ b/spacetraders/models/ship_cargo_item.py
@@ -12,14 +12,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ShipCargoItem")
 
 
-@attr.s(auto_attribs=True)
-class ShipCargoItem:
+class ShipCargoItem(BaseModel):
     """The type of cargo item and the number of units.
 
     Attributes:
@@ -29,51 +29,14 @@ class ShipCargoItem:
         units (int): The number of units of the cargo item.
     """
 
-    symbol: str
-    name: str
-    description: str
-    units: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    units: int = Field(alias="units")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        name = self.name
-        description = self.description
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-                "units": units,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        units = d.pop("units")
-
-        ship_cargo_item = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-            units=units,
-        )
-
-        ship_cargo_item.additional_properties = d
-        return ship_cargo_item
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_crew.py
+++ b/spacetraders/models/ship_crew.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_crew_rotation import ShipCrewRotation
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="ShipCrew")
 
 
-@attr.s(auto_attribs=True)
-class ShipCrew:
+class ShipCrew(BaseModel):
     """The ship's crew service and maintain the ship's systems and equipment.
 
     Attributes:
@@ -35,64 +35,16 @@ class ShipCrew:
             civilized waypoint.
     """
 
-    current: int
-    required: int
-    capacity: int
-    morale: int
-    wages: int
+    current: int = Field(alias="current")
+    required: int = Field(alias="required")
+    capacity: int = Field(alias="capacity")
+    morale: int = Field(alias="morale")
+    wages: int = Field(alias="wages")
     rotation: ShipCrewRotation = ShipCrewRotation.STRICT
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        current = self.current
-        required = self.required
-        capacity = self.capacity
-        rotation = self.rotation.value
-
-        morale = self.morale
-        wages = self.wages
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "current": current,
-                "required": required,
-                "capacity": capacity,
-                "rotation": rotation,
-                "morale": morale,
-                "wages": wages,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        current = d.pop("current")
-
-        required = d.pop("required")
-
-        capacity = d.pop("capacity")
-
-        rotation = ShipCrewRotation(d.pop("rotation"))
-
-        morale = d.pop("morale")
-
-        wages = d.pop("wages")
-
-        ship_crew = cls(
-            current=current,
-            required=required,
-            capacity=capacity,
-            rotation=rotation,
-            morale=morale,
-            wages=wages,
-        )
-
-        ship_crew.additional_properties = d
-        return ship_crew
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_engine.py
+++ b/spacetraders/models/ship_engine.py
@@ -14,19 +14,16 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_engine_symbol import ShipEngineSymbol
+from ..models.ship_requirements import ShipRequirements
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_requirements import ShipRequirements
-
 
 T = TypeVar("T", bound="ShipEngine")
 
 
-@attr.s(auto_attribs=True)
-class ShipEngine:
+class ShipEngine(BaseModel):
     """The engine determines how quickly a ship travels between waypoints.
 
     Attributes:
@@ -39,70 +36,16 @@ class ShipEngine:
             new.
     """
 
-    symbol: ShipEngineSymbol
-    name: str
-    description: str
-    speed: float
-    requirements: "ShipRequirements"
+    symbol: ShipEngineSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    speed: float = Field(alias="speed")
+    requirements: "ShipRequirements" = Field(alias="requirements")
     condition: Union[Unset, int] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_requirements import ShipRequirements
-
-        symbol = self.symbol.value
-
-        name = self.name
-        description = self.description
-        speed = self.speed
-        requirements = self.requirements.to_dict()
-
-        condition = self.condition
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-                "speed": speed,
-                "requirements": requirements,
-            }
-        )
-        if condition is not UNSET:
-            field_dict["condition"] = condition
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_requirements import ShipRequirements
-
-        d = src_dict.copy()
-        symbol = ShipEngineSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        speed = d.pop("speed")
-
-        requirements = ShipRequirements.from_dict(d.pop("requirements"))
-
-        condition = d.pop("condition", UNSET)
-
-        ship_engine = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-            speed=speed,
-            requirements=requirements,
-            condition=condition,
-        )
-
-        ship_engine.additional_properties = d
-        return ship_engine
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_frame.py
+++ b/spacetraders/models/ship_frame.py
@@ -14,19 +14,16 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_frame_symbol import ShipFrameSymbol
+from ..models.ship_requirements import ShipRequirements
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_requirements import ShipRequirements
-
 
 T = TypeVar("T", bound="ShipFrame")
 
 
-@attr.s(auto_attribs=True)
-class ShipFrame:
+class ShipFrame(BaseModel):
     """The frame of the ship. The frame determines the number of modules and mounting points of the ship, as well as base
     fuel capacity. As the condition of the frame takes more wear, the ship will become more sluggish and less
     maneuverable.
@@ -43,82 +40,18 @@ class ShipFrame:
                 new.
     """
 
-    symbol: ShipFrameSymbol
-    name: str
-    description: str
-    module_slots: int
-    mounting_points: int
-    fuel_capacity: int
-    requirements: "ShipRequirements"
+    symbol: ShipFrameSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    module_slots: int = Field(alias="moduleSlots")
+    mounting_points: int = Field(alias="mountingPoints")
+    fuel_capacity: int = Field(alias="fuelCapacity")
+    requirements: "ShipRequirements" = Field(alias="requirements")
     condition: Union[Unset, int] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_requirements import ShipRequirements
-
-        symbol = self.symbol.value
-
-        name = self.name
-        description = self.description
-        module_slots = self.module_slots
-        mounting_points = self.mounting_points
-        fuel_capacity = self.fuel_capacity
-        requirements = self.requirements.to_dict()
-
-        condition = self.condition
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-                "moduleSlots": module_slots,
-                "mountingPoints": mounting_points,
-                "fuelCapacity": fuel_capacity,
-                "requirements": requirements,
-            }
-        )
-        if condition is not UNSET:
-            field_dict["condition"] = condition
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_requirements import ShipRequirements
-
-        d = src_dict.copy()
-        symbol = ShipFrameSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        module_slots = d.pop("moduleSlots")
-
-        mounting_points = d.pop("mountingPoints")
-
-        fuel_capacity = d.pop("fuelCapacity")
-
-        requirements = ShipRequirements.from_dict(d.pop("requirements"))
-
-        condition = d.pop("condition", UNSET)
-
-        ship_frame = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-            module_slots=module_slots,
-            mounting_points=mounting_points,
-            fuel_capacity=fuel_capacity,
-            requirements=requirements,
-            condition=condition,
-        )
-
-        ship_frame.additional_properties = d
-        return ship_frame
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_fuel.py
+++ b/spacetraders/models/ship_fuel.py
@@ -14,18 +14,15 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_fuel_consumed import ShipFuelConsumed
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_fuel_consumed import ShipFuelConsumed
-
 
 T = TypeVar("T", bound="ShipFuel")
 
 
-@attr.s(auto_attribs=True)
-class ShipFuel:
+class ShipFuel(BaseModel):
     """Details of the ship's fuel tanks including how much fuel was consumed during the last transit or action.
 
     Attributes:
@@ -34,57 +31,13 @@ class ShipFuel:
         consumed (Union[Unset, ShipFuelConsumed]):
     """
 
-    current: int
-    capacity: int
+    current: int = Field(alias="current")
+    capacity: int = Field(alias="capacity")
     consumed: Union[Unset, "ShipFuelConsumed"] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_fuel_consumed import ShipFuelConsumed
-
-        current = self.current
-        capacity = self.capacity
-        consumed: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.consumed, Unset):
-            consumed = self.consumed.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "current": current,
-                "capacity": capacity,
-            }
-        )
-        if consumed is not UNSET:
-            field_dict["consumed"] = consumed
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_fuel_consumed import ShipFuelConsumed
-
-        d = src_dict.copy()
-        current = d.pop("current")
-
-        capacity = d.pop("capacity")
-
-        _consumed = d.pop("consumed", UNSET)
-        consumed: Union[Unset, ShipFuelConsumed]
-        if isinstance(_consumed, Unset):
-            consumed = UNSET
-        else:
-            consumed = ShipFuelConsumed.from_dict(_consumed)
-
-        ship_fuel = cls(
-            current=current,
-            capacity=capacity,
-            consumed=consumed,
-        )
-
-        ship_fuel.additional_properties = d
-        return ship_fuel
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_fuel_consumed.py
+++ b/spacetraders/models/ship_fuel_consumed.py
@@ -15,53 +15,26 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ShipFuelConsumed")
 
 
-@attr.s(auto_attribs=True)
-class ShipFuelConsumed:
+class ShipFuelConsumed(BaseModel):
     """
     Attributes:
         amount (int): The amount of fuel consumed by the most recent transit or action.
         timestamp (datetime.datetime): The time at which the fuel was consumed.
     """
 
-    amount: int
-    timestamp: datetime.datetime
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    amount: int = Field(alias="amount")
+    timestamp: datetime.datetime = Field(alias="timestamp")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        amount = self.amount
-        timestamp = self.timestamp.isoformat()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "amount": amount,
-                "timestamp": timestamp,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        amount = d.pop("amount")
-
-        timestamp = isoparse(d.pop("timestamp"))
-
-        ship_fuel_consumed = cls(
-            amount=amount,
-            timestamp=timestamp,
-        )
-
-        ship_fuel_consumed.additional_properties = d
-        return ship_fuel_consumed
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_module.py
+++ b/spacetraders/models/ship_module.py
@@ -14,19 +14,16 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_module_symbol import ShipModuleSymbol
+from ..models.ship_requirements import ShipRequirements
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_requirements import ShipRequirements
-
 
 T = TypeVar("T", bound="ShipModule")
 
 
-@attr.s(auto_attribs=True)
-class ShipModule:
+class ShipModule(BaseModel):
     """A module can be installed in a ship and provides a set of capabilities such as storage space or quarters for crew.
     Module installations are permanent.
 
@@ -39,72 +36,16 @@ class ShipModule:
             description (Union[Unset, str]):
     """
 
-    symbol: ShipModuleSymbol
-    name: str
-    requirements: "ShipRequirements"
+    symbol: ShipModuleSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    requirements: "ShipRequirements" = Field(alias="requirements")
     capacity: Union[Unset, int] = UNSET
     range_: Union[Unset, int] = UNSET
     description: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_requirements import ShipRequirements
-
-        symbol = self.symbol.value
-
-        name = self.name
-        requirements = self.requirements.to_dict()
-
-        capacity = self.capacity
-        range_ = self.range_
-        description = self.description
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "requirements": requirements,
-            }
-        )
-        if capacity is not UNSET:
-            field_dict["capacity"] = capacity
-        if range_ is not UNSET:
-            field_dict["range"] = range_
-        if description is not UNSET:
-            field_dict["description"] = description
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_requirements import ShipRequirements
-
-        d = src_dict.copy()
-        symbol = ShipModuleSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        requirements = ShipRequirements.from_dict(d.pop("requirements"))
-
-        capacity = d.pop("capacity", UNSET)
-
-        range_ = d.pop("range", UNSET)
-
-        description = d.pop("description", UNSET)
-
-        ship_module = cls(
-            symbol=symbol,
-            name=name,
-            requirements=requirements,
-            capacity=capacity,
-            range_=range_,
-            description=description,
-        )
-
-        ship_module.additional_properties = d
-        return ship_module
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_mount.py
+++ b/spacetraders/models/ship_mount.py
@@ -14,20 +14,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_mount_deposits_item import ShipMountDepositsItem
 from ..models.ship_mount_symbol import ShipMountSymbol
+from ..models.ship_requirements import ShipRequirements
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_requirements import ShipRequirements
-
 
 T = TypeVar("T", bound="ShipMount")
 
 
-@attr.s(auto_attribs=True)
-class ShipMount:
+class ShipMount(BaseModel):
     """A mount is installed on the exterier of a ship.
 
     Attributes:
@@ -39,83 +36,16 @@ class ShipMount:
         deposits (Union[Unset, List[ShipMountDepositsItem]]):
     """
 
-    symbol: ShipMountSymbol
-    name: str
-    requirements: "ShipRequirements"
+    symbol: ShipMountSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    requirements: "ShipRequirements" = Field(alias="requirements")
     description: Union[Unset, str] = UNSET
     strength: Union[Unset, int] = UNSET
     deposits: Union[Unset, List[ShipMountDepositsItem]] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_requirements import ShipRequirements
-
-        symbol = self.symbol.value
-
-        name = self.name
-        requirements = self.requirements.to_dict()
-
-        description = self.description
-        strength = self.strength
-        deposits: Union[Unset, List[str]] = UNSET
-        if not isinstance(self.deposits, Unset):
-            deposits = []
-            for deposits_item_data in self.deposits:
-                deposits_item = deposits_item_data.value
-
-                deposits.append(deposits_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "requirements": requirements,
-            }
-        )
-        if description is not UNSET:
-            field_dict["description"] = description
-        if strength is not UNSET:
-            field_dict["strength"] = strength
-        if deposits is not UNSET:
-            field_dict["deposits"] = deposits
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_requirements import ShipRequirements
-
-        d = src_dict.copy()
-        symbol = ShipMountSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        requirements = ShipRequirements.from_dict(d.pop("requirements"))
-
-        description = d.pop("description", UNSET)
-
-        strength = d.pop("strength", UNSET)
-
-        deposits = []
-        _deposits = d.pop("deposits", UNSET)
-        for deposits_item_data in _deposits or []:
-            deposits_item = ShipMountDepositsItem(deposits_item_data)
-
-            deposits.append(deposits_item)
-
-        ship_mount = cls(
-            symbol=symbol,
-            name=name,
-            requirements=requirements,
-            description=description,
-            strength=strength,
-            deposits=deposits,
-        )
-
-        ship_mount.additional_properties = d
-        return ship_mount
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_nav.py
+++ b/spacetraders/models/ship_nav.py
@@ -13,20 +13,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_nav_flight_mode import ShipNavFlightMode
+from ..models.ship_nav_route import ShipNavRoute
 from ..models.ship_nav_status import ShipNavStatus
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_nav_route import ShipNavRoute
-
 
 T = TypeVar("T", bound="ShipNav")
 
 
-@attr.s(auto_attribs=True)
-class ShipNav:
+class ShipNav(BaseModel):
     """The navigation information of the ship.
 
     Attributes:
@@ -39,63 +36,15 @@ class ShipNav:
             ShipNavFlightMode.CRUISE.
     """
 
-    system_symbol: str
-    waypoint_symbol: str
-    route: "ShipNavRoute"
-    status: ShipNavStatus
+    system_symbol: str = Field(alias="systemSymbol")
+    waypoint_symbol: str = Field(alias="waypointSymbol")
+    route: "ShipNavRoute" = Field(alias="route")
+    status: ShipNavStatus = Field(alias="status")
     flight_mode: ShipNavFlightMode = ShipNavFlightMode.CRUISE
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_nav_route import ShipNavRoute
-
-        system_symbol = self.system_symbol
-        waypoint_symbol = self.waypoint_symbol
-        route = self.route.to_dict()
-
-        status = self.status.value
-
-        flight_mode = self.flight_mode.value
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "systemSymbol": system_symbol,
-                "waypointSymbol": waypoint_symbol,
-                "route": route,
-                "status": status,
-                "flightMode": flight_mode,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_nav_route import ShipNavRoute
-
-        d = src_dict.copy()
-        system_symbol = d.pop("systemSymbol")
-
-        waypoint_symbol = d.pop("waypointSymbol")
-
-        route = ShipNavRoute.from_dict(d.pop("route"))
-
-        status = ShipNavStatus(d.pop("status"))
-
-        flight_mode = ShipNavFlightMode(d.pop("flightMode"))
-
-        ship_nav = cls(
-            system_symbol=system_symbol,
-            waypoint_symbol=waypoint_symbol,
-            route=route,
-            status=status,
-            flight_mode=flight_mode,
-        )
-
-        ship_nav.additional_properties = d
-        return ship_nav
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_nav_route.py
+++ b/spacetraders/models/ship_nav_route.py
@@ -15,18 +15,15 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
+from ..models.ship_nav_route_waypoint import ShipNavRouteWaypoint
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_nav_route_waypoint import ShipNavRouteWaypoint
-
 
 T = TypeVar("T", bound="ShipNavRoute")
 
 
-@attr.s(auto_attribs=True)
-class ShipNavRoute:
+class ShipNavRoute(BaseModel):
     """The routing information for the ship's most recent transit or current location.
 
     Attributes:
@@ -37,58 +34,14 @@ class ShipNavRoute:
             expected time of arrival.
     """
 
-    destination: "ShipNavRouteWaypoint"
-    departure: "ShipNavRouteWaypoint"
-    departure_time: datetime.datetime
-    arrival: datetime.datetime
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    destination: "ShipNavRouteWaypoint" = Field(alias="destination")
+    departure: "ShipNavRouteWaypoint" = Field(alias="departure")
+    departure_time: datetime.datetime = Field(alias="departureTime")
+    arrival: datetime.datetime = Field(alias="arrival")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_nav_route_waypoint import ShipNavRouteWaypoint
-
-        destination = self.destination.to_dict()
-
-        departure = self.departure.to_dict()
-
-        departure_time = self.departure_time.isoformat()
-
-        arrival = self.arrival.isoformat()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "destination": destination,
-                "departure": departure,
-                "departureTime": departure_time,
-                "arrival": arrival,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_nav_route_waypoint import ShipNavRouteWaypoint
-
-        d = src_dict.copy()
-        destination = ShipNavRouteWaypoint.from_dict(d.pop("destination"))
-
-        departure = ShipNavRouteWaypoint.from_dict(d.pop("departure"))
-
-        departure_time = isoparse(d.pop("departureTime"))
-
-        arrival = isoparse(d.pop("arrival"))
-
-        ship_nav_route = cls(
-            destination=destination,
-            departure=departure,
-            departure_time=departure_time,
-            arrival=arrival,
-        )
-
-        ship_nav_route.additional_properties = d
-        return ship_nav_route
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_nav_route_waypoint.py
+++ b/spacetraders/models/ship_nav_route_waypoint.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.waypoint_type import WaypointType
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="ShipNavRouteWaypoint")
 
 
-@attr.s(auto_attribs=True)
-class ShipNavRouteWaypoint:
+class ShipNavRouteWaypoint(BaseModel):
     """The destination or departure of a ships nav route.
 
     Attributes:
@@ -31,58 +31,15 @@ class ShipNavRouteWaypoint:
         y (int):
     """
 
-    symbol: str
-    type: WaypointType
-    system_symbol: str
-    x: int
-    y: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    type: WaypointType = Field(alias="type")
+    system_symbol: str = Field(alias="systemSymbol")
+    x: int = Field(alias="x")
+    y: int = Field(alias="y")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        type = self.type.value
-
-        system_symbol = self.system_symbol
-        x = self.x
-        y = self.y
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "type": type,
-                "systemSymbol": system_symbol,
-                "x": x,
-                "y": y,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        type = WaypointType(d.pop("type"))
-
-        system_symbol = d.pop("systemSymbol")
-
-        x = d.pop("x")
-
-        y = d.pop("y")
-
-        ship_nav_route_waypoint = cls(
-            symbol=symbol,
-            type=type,
-            system_symbol=system_symbol,
-            x=x,
-            y=y,
-        )
-
-        ship_nav_route_waypoint.additional_properties = d
-        return ship_nav_route_waypoint
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_reactor.py
+++ b/spacetraders/models/ship_reactor.py
@@ -14,19 +14,16 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_reactor_symbol import ShipReactorSymbol
+from ..models.ship_requirements import ShipRequirements
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_requirements import ShipRequirements
-
 
 T = TypeVar("T", bound="ShipReactor")
 
 
-@attr.s(auto_attribs=True)
-class ShipReactor:
+class ShipReactor(BaseModel):
     """The reactor of the ship. The reactor is responsible for powering the ship's systems and weapons.
 
     Attributes:
@@ -39,70 +36,16 @@ class ShipReactor:
             new.
     """
 
-    symbol: ShipReactorSymbol
-    name: str
-    description: str
-    power_output: int
-    requirements: "ShipRequirements"
+    symbol: ShipReactorSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    power_output: int = Field(alias="powerOutput")
+    requirements: "ShipRequirements" = Field(alias="requirements")
     condition: Union[Unset, int] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_requirements import ShipRequirements
-
-        symbol = self.symbol.value
-
-        name = self.name
-        description = self.description
-        power_output = self.power_output
-        requirements = self.requirements.to_dict()
-
-        condition = self.condition
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-                "powerOutput": power_output,
-                "requirements": requirements,
-            }
-        )
-        if condition is not UNSET:
-            field_dict["condition"] = condition
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_requirements import ShipRequirements
-
-        d = src_dict.copy()
-        symbol = ShipReactorSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        power_output = d.pop("powerOutput")
-
-        requirements = ShipRequirements.from_dict(d.pop("requirements"))
-
-        condition = d.pop("condition", UNSET)
-
-        ship_reactor = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-            power_output=power_output,
-            requirements=requirements,
-            condition=condition,
-        )
-
-        ship_reactor.additional_properties = d
-        return ship_reactor
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_refine_json_body.py
+++ b/spacetraders/models/ship_refine_json_body.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_refine_json_body_produce import ShipRefineJsonBodyProduce
 from ..types import UNSET, Unset
@@ -19,40 +20,17 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="ShipRefineJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class ShipRefineJsonBody:
+class ShipRefineJsonBody(BaseModel):
     """
     Attributes:
         produce (ShipRefineJsonBodyProduce):
     """
 
-    produce: ShipRefineJsonBodyProduce
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    produce: ShipRefineJsonBodyProduce = Field(alias="produce")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        produce = self.produce.value
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "produce": produce,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        produce = ShipRefineJsonBodyProduce(d.pop("produce"))
-
-        ship_refine_json_body = cls(
-            produce=produce,
-        )
-
-        ship_refine_json_body.additional_properties = d
-        return ship_refine_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_refine_ship_refine_200_response.py
+++ b/spacetraders/models/ship_refine_ship_refine_200_response.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_refine_ship_refine_200_response_data import (
+    ShipRefineShipRefine200ResponseData,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_refine_ship_refine_200_response_data import (
-        ShipRefineShipRefine200ResponseData,
-    )
-
 
 T = TypeVar("T", bound="ShipRefineShipRefine200Response")
 
 
-@attr.s(auto_attribs=True)
-class ShipRefineShipRefine200Response:
+class ShipRefineShipRefine200Response(BaseModel):
     """
     Attributes:
         data (ShipRefineShipRefine200ResponseData):
     """
 
-    data: "ShipRefineShipRefine200ResponseData"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "ShipRefineShipRefine200ResponseData" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_refine_ship_refine_200_response_data import (
-            ShipRefineShipRefine200ResponseData,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_refine_ship_refine_200_response_data import (
-            ShipRefineShipRefine200ResponseData,
-        )
-
-        d = src_dict.copy()
-        data = ShipRefineShipRefine200ResponseData.from_dict(d.pop("data"))
-
-        ship_refine_ship_refine_200_response = cls(
-            data=data,
-        )
-
-        ship_refine_ship_refine_200_response.additional_properties = d
-        return ship_refine_ship_refine_200_response
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_refine_ship_refine_200_response_data.py
+++ b/spacetraders/models/ship_refine_ship_refine_200_response_data.py
@@ -13,25 +13,22 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.cooldown import Cooldown
+from ..models.ship_cargo import ShipCargo
+from ..models.ship_refine_ship_refine_200_response_data_consumed_item import (
+    ShipRefineShipRefine200ResponseDataConsumedItem,
+)
+from ..models.ship_refine_ship_refine_200_response_data_produced_item import (
+    ShipRefineShipRefine200ResponseDataProducedItem,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.cooldown import Cooldown
-    from ..models.ship_cargo import ShipCargo
-    from ..models.ship_refine_ship_refine_200_response_data_consumed_item import (
-        ShipRefineShipRefine200ResponseDataConsumedItem,
-    )
-    from ..models.ship_refine_ship_refine_200_response_data_produced_item import (
-        ShipRefineShipRefine200ResponseDataProducedItem,
-    )
-
 
 T = TypeVar("T", bound="ShipRefineShipRefine200ResponseData")
 
 
-@attr.s(auto_attribs=True)
-class ShipRefineShipRefine200ResponseData:
+class ShipRefineShipRefine200ResponseData(BaseModel):
     """
     Attributes:
         cargo (ShipCargo):
@@ -40,94 +37,18 @@ class ShipRefineShipRefine200ResponseData:
         consumed (List['ShipRefineShipRefine200ResponseDataConsumedItem']):
     """
 
-    cargo: "ShipCargo"
-    cooldown: "Cooldown"
-    produced: List["ShipRefineShipRefine200ResponseDataProducedItem"]
-    consumed: List["ShipRefineShipRefine200ResponseDataConsumedItem"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cargo: "ShipCargo" = Field(alias="cargo")
+    cooldown: "Cooldown" = Field(alias="cooldown")
+    produced: List["ShipRefineShipRefine200ResponseDataProducedItem"] = Field(
+        alias="produced"
+    )
+    consumed: List["ShipRefineShipRefine200ResponseDataConsumedItem"] = Field(
+        alias="consumed"
+    )
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.cooldown import Cooldown
-        from ..models.ship_cargo import ShipCargo
-        from ..models.ship_refine_ship_refine_200_response_data_consumed_item import (
-            ShipRefineShipRefine200ResponseDataConsumedItem,
-        )
-        from ..models.ship_refine_ship_refine_200_response_data_produced_item import (
-            ShipRefineShipRefine200ResponseDataProducedItem,
-        )
-
-        cargo = self.cargo.to_dict()
-
-        cooldown = self.cooldown.to_dict()
-
-        produced = []
-        for produced_item_data in self.produced:
-            produced_item = produced_item_data.to_dict()
-
-            produced.append(produced_item)
-
-        consumed = []
-        for consumed_item_data in self.consumed:
-            consumed_item = consumed_item_data.to_dict()
-
-            consumed.append(consumed_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cargo": cargo,
-                "cooldown": cooldown,
-                "produced": produced,
-                "consumed": consumed,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.cooldown import Cooldown
-        from ..models.ship_cargo import ShipCargo
-        from ..models.ship_refine_ship_refine_200_response_data_consumed_item import (
-            ShipRefineShipRefine200ResponseDataConsumedItem,
-        )
-        from ..models.ship_refine_ship_refine_200_response_data_produced_item import (
-            ShipRefineShipRefine200ResponseDataProducedItem,
-        )
-
-        d = src_dict.copy()
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        cooldown = Cooldown.from_dict(d.pop("cooldown"))
-
-        produced = []
-        _produced = d.pop("produced")
-        for produced_item_data in _produced:
-            produced_item = ShipRefineShipRefine200ResponseDataProducedItem.from_dict(
-                produced_item_data
-            )
-
-            produced.append(produced_item)
-
-        consumed = []
-        _consumed = d.pop("consumed")
-        for consumed_item_data in _consumed:
-            consumed_item = ShipRefineShipRefine200ResponseDataConsumedItem.from_dict(
-                consumed_item_data
-            )
-
-            consumed.append(consumed_item)
-
-        ship_refine_ship_refine_200_response_data = cls(
-            cargo=cargo,
-            cooldown=cooldown,
-            produced=produced,
-            consumed=consumed,
-        )
-
-        ship_refine_ship_refine_200_response_data.additional_properties = d
-        return ship_refine_ship_refine_200_response_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_refine_ship_refine_200_response_data_consumed_item.py
+++ b/spacetraders/models/ship_refine_ship_refine_200_response_data_consumed_item.py
@@ -13,14 +13,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ShipRefineShipRefine200ResponseDataConsumedItem")
 
 
-@attr.s(auto_attribs=True)
-class ShipRefineShipRefine200ResponseDataConsumedItem:
+class ShipRefineShipRefine200ResponseDataConsumedItem(BaseModel):
     """
     Attributes:
         trade_symbol (Union[Unset, str]):
@@ -29,38 +29,10 @@ class ShipRefineShipRefine200ResponseDataConsumedItem:
 
     trade_symbol: Union[Unset, str] = UNSET
     units: Union[Unset, int] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        trade_symbol = self.trade_symbol
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if trade_symbol is not UNSET:
-            field_dict["tradeSymbol"] = trade_symbol
-        if units is not UNSET:
-            field_dict["units"] = units
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        trade_symbol = d.pop("tradeSymbol", UNSET)
-
-        units = d.pop("units", UNSET)
-
-        ship_refine_ship_refine_200_response_data_consumed_item = cls(
-            trade_symbol=trade_symbol,
-            units=units,
-        )
-
-        ship_refine_ship_refine_200_response_data_consumed_item.additional_properties = (
-            d
-        )
-        return ship_refine_ship_refine_200_response_data_consumed_item
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_refine_ship_refine_200_response_data_produced_item.py
+++ b/spacetraders/models/ship_refine_ship_refine_200_response_data_produced_item.py
@@ -13,14 +13,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ShipRefineShipRefine200ResponseDataProducedItem")
 
 
-@attr.s(auto_attribs=True)
-class ShipRefineShipRefine200ResponseDataProducedItem:
+class ShipRefineShipRefine200ResponseDataProducedItem(BaseModel):
     """
     Attributes:
         trade_symbol (Union[Unset, str]):
@@ -29,38 +29,10 @@ class ShipRefineShipRefine200ResponseDataProducedItem:
 
     trade_symbol: Union[Unset, str] = UNSET
     units: Union[Unset, int] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        trade_symbol = self.trade_symbol
-        units = self.units
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if trade_symbol is not UNSET:
-            field_dict["tradeSymbol"] = trade_symbol
-        if units is not UNSET:
-            field_dict["units"] = units
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        trade_symbol = d.pop("tradeSymbol", UNSET)
-
-        units = d.pop("units", UNSET)
-
-        ship_refine_ship_refine_200_response_data_produced_item = cls(
-            trade_symbol=trade_symbol,
-            units=units,
-        )
-
-        ship_refine_ship_refine_200_response_data_produced_item.additional_properties = (
-            d
-        )
-        return ship_refine_ship_refine_200_response_data_produced_item
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_registration.py
+++ b/spacetraders/models/ship_registration.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_role import ShipRole
 from ..types import UNSET, Unset
@@ -20,8 +21,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="ShipRegistration")
 
 
-@attr.s(auto_attribs=True)
-class ShipRegistration:
+class ShipRegistration(BaseModel):
     """The public registration information of the ship
 
     Attributes:
@@ -30,47 +30,13 @@ class ShipRegistration:
         faction_symbol (Union[Unset, str]): The symbol of the faction the ship is registered with
     """
 
-    name: str
-    role: ShipRole
+    name: str = Field(alias="name")
+    role: ShipRole = Field(alias="role")
     faction_symbol: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        name = self.name
-        role = self.role.value
-
-        faction_symbol = self.faction_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "name": name,
-                "role": role,
-            }
-        )
-        if faction_symbol is not UNSET:
-            field_dict["factionSymbol"] = faction_symbol
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        name = d.pop("name")
-
-        role = ShipRole(d.pop("role"))
-
-        faction_symbol = d.pop("factionSymbol", UNSET)
-
-        ship_registration = cls(
-            name=name,
-            role=role,
-            faction_symbol=faction_symbol,
-        )
-
-        ship_registration.additional_properties = d
-        return ship_registration
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/ship_requirements.py
+++ b/spacetraders/models/ship_requirements.py
@@ -13,14 +13,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ShipRequirements")
 
 
-@attr.s(auto_attribs=True)
-class ShipRequirements:
+class ShipRequirements(BaseModel):
     """The requirements for installation on a ship
 
     Attributes:
@@ -32,42 +32,10 @@ class ShipRequirements:
     power: Union[Unset, int] = UNSET
     crew: Union[Unset, int] = UNSET
     slots: Union[Unset, int] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        power = self.power
-        crew = self.crew
-        slots = self.slots
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if power is not UNSET:
-            field_dict["power"] = power
-        if crew is not UNSET:
-            field_dict["crew"] = crew
-        if slots is not UNSET:
-            field_dict["slots"] = slots
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        power = d.pop("power", UNSET)
-
-        crew = d.pop("crew", UNSET)
-
-        slots = d.pop("slots", UNSET)
-
-        ship_requirements = cls(
-            power=power,
-            crew=crew,
-            slots=slots,
-        )
-
-        ship_requirements.additional_properties = d
-        return ship_requirements
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/shipyard.py
+++ b/spacetraders/models/shipyard.py
@@ -14,20 +14,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.shipyard_ship import ShipyardShip
+from ..models.shipyard_ship_types_item import ShipyardShipTypesItem
+from ..models.shipyard_transaction import ShipyardTransaction
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.shipyard_ship import ShipyardShip
-    from ..models.shipyard_ship_types_item import ShipyardShipTypesItem
-    from ..models.shipyard_transaction import ShipyardTransaction
-
 
 T = TypeVar("T", bound="Shipyard")
 
 
-@attr.s(auto_attribs=True)
-class Shipyard:
+class Shipyard(BaseModel):
     """
     Attributes:
         symbol (str): The symbol of the shipyard. The symbol is the same as the waypoint where the shipyard is located.
@@ -36,94 +33,14 @@ class Shipyard:
         ships (Union[Unset, List['ShipyardShip']]): The ships that are currently available for purchase at the shipyard.
     """
 
-    symbol: str
-    ship_types: List["ShipyardShipTypesItem"]
+    symbol: str = Field(alias="symbol")
+    ship_types: List["ShipyardShipTypesItem"] = Field(alias="shipTypes")
     transactions: Union[Unset, List["ShipyardTransaction"]] = UNSET
     ships: Union[Unset, List["ShipyardShip"]] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.shipyard_ship import ShipyardShip
-        from ..models.shipyard_ship_types_item import ShipyardShipTypesItem
-        from ..models.shipyard_transaction import ShipyardTransaction
-
-        symbol = self.symbol
-        ship_types = []
-        for ship_types_item_data in self.ship_types:
-            ship_types_item = ship_types_item_data.to_dict()
-
-            ship_types.append(ship_types_item)
-
-        transactions: Union[Unset, List[Dict[str, Any]]] = UNSET
-        if not isinstance(self.transactions, Unset):
-            transactions = []
-            for transactions_item_data in self.transactions:
-                transactions_item = transactions_item_data.to_dict()
-
-                transactions.append(transactions_item)
-
-        ships: Union[Unset, List[Dict[str, Any]]] = UNSET
-        if not isinstance(self.ships, Unset):
-            ships = []
-            for ships_item_data in self.ships:
-                ships_item = ships_item_data.to_dict()
-
-                ships.append(ships_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "shipTypes": ship_types,
-            }
-        )
-        if transactions is not UNSET:
-            field_dict["transactions"] = transactions
-        if ships is not UNSET:
-            field_dict["ships"] = ships
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.shipyard_ship import ShipyardShip
-        from ..models.shipyard_ship_types_item import ShipyardShipTypesItem
-        from ..models.shipyard_transaction import ShipyardTransaction
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        ship_types = []
-        _ship_types = d.pop("shipTypes")
-        for ship_types_item_data in _ship_types:
-            ship_types_item = ShipyardShipTypesItem.from_dict(ship_types_item_data)
-
-            ship_types.append(ship_types_item)
-
-        transactions = []
-        _transactions = d.pop("transactions", UNSET)
-        for transactions_item_data in _transactions or []:
-            transactions_item = ShipyardTransaction.from_dict(transactions_item_data)
-
-            transactions.append(transactions_item)
-
-        ships = []
-        _ships = d.pop("ships", UNSET)
-        for ships_item_data in _ships or []:
-            ships_item = ShipyardShip.from_dict(ships_item_data)
-
-            ships.append(ships_item)
-
-        shipyard = cls(
-            symbol=symbol,
-            ship_types=ship_types,
-            transactions=transactions,
-            ships=ships,
-        )
-
-        shipyard.additional_properties = d
-        return shipyard
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/shipyard_ship.py
+++ b/spacetraders/models/shipyard_ship.py
@@ -14,23 +14,20 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_engine import ShipEngine
+from ..models.ship_frame import ShipFrame
+from ..models.ship_module import ShipModule
+from ..models.ship_mount import ShipMount
+from ..models.ship_reactor import ShipReactor
 from ..models.ship_type import ShipType
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_engine import ShipEngine
-    from ..models.ship_frame import ShipFrame
-    from ..models.ship_module import ShipModule
-    from ..models.ship_mount import ShipMount
-    from ..models.ship_reactor import ShipReactor
-
 
 T = TypeVar("T", bound="ShipyardShip")
 
 
-@attr.s(auto_attribs=True)
-class ShipyardShip:
+class ShipyardShip(BaseModel):
     """
     Attributes:
         name (str):
@@ -47,124 +44,19 @@ class ShipyardShip:
         type (Union[Unset, ShipType]):
     """
 
-    name: str
-    description: str
-    purchase_price: int
-    frame: "ShipFrame"
-    reactor: "ShipReactor"
-    engine: "ShipEngine"
-    modules: List["ShipModule"]
-    mounts: List["ShipMount"]
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    purchase_price: int = Field(alias="purchasePrice")
+    frame: "ShipFrame" = Field(alias="frame")
+    reactor: "ShipReactor" = Field(alias="reactor")
+    engine: "ShipEngine" = Field(alias="engine")
+    modules: List["ShipModule"] = Field(alias="modules")
+    mounts: List["ShipMount"] = Field(alias="mounts")
     type: Union[Unset, ShipType] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_engine import ShipEngine
-        from ..models.ship_frame import ShipFrame
-        from ..models.ship_module import ShipModule
-        from ..models.ship_mount import ShipMount
-        from ..models.ship_reactor import ShipReactor
-
-        name = self.name
-        description = self.description
-        purchase_price = self.purchase_price
-        frame = self.frame.to_dict()
-
-        reactor = self.reactor.to_dict()
-
-        engine = self.engine.to_dict()
-
-        modules = []
-        for modules_item_data in self.modules:
-            modules_item = modules_item_data.to_dict()
-
-            modules.append(modules_item)
-
-        mounts = []
-        for mounts_item_data in self.mounts:
-            mounts_item = mounts_item_data.to_dict()
-
-            mounts.append(mounts_item)
-
-        type: Union[Unset, str] = UNSET
-        if not isinstance(self.type, Unset):
-            type = self.type.value
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "name": name,
-                "description": description,
-                "purchasePrice": purchase_price,
-                "frame": frame,
-                "reactor": reactor,
-                "engine": engine,
-                "modules": modules,
-                "mounts": mounts,
-            }
-        )
-        if type is not UNSET:
-            field_dict["type"] = type
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_engine import ShipEngine
-        from ..models.ship_frame import ShipFrame
-        from ..models.ship_module import ShipModule
-        from ..models.ship_mount import ShipMount
-        from ..models.ship_reactor import ShipReactor
-
-        d = src_dict.copy()
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        purchase_price = d.pop("purchasePrice")
-
-        frame = ShipFrame.from_dict(d.pop("frame"))
-
-        reactor = ShipReactor.from_dict(d.pop("reactor"))
-
-        engine = ShipEngine.from_dict(d.pop("engine"))
-
-        modules = []
-        _modules = d.pop("modules")
-        for modules_item_data in _modules:
-            modules_item = ShipModule.from_dict(modules_item_data)
-
-            modules.append(modules_item)
-
-        mounts = []
-        _mounts = d.pop("mounts")
-        for mounts_item_data in _mounts:
-            mounts_item = ShipMount.from_dict(mounts_item_data)
-
-            mounts.append(mounts_item)
-
-        _type = d.pop("type", UNSET)
-        type: Union[Unset, ShipType]
-        if isinstance(_type, Unset):
-            type = UNSET
-        else:
-            type = ShipType(_type)
-
-        shipyard_ship = cls(
-            name=name,
-            description=description,
-            purchase_price=purchase_price,
-            frame=frame,
-            reactor=reactor,
-            engine=engine,
-            modules=modules,
-            mounts=mounts,
-            type=type,
-        )
-
-        shipyard_ship.additional_properties = d
-        return shipyard_ship
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/shipyard_ship_types_item.py
+++ b/spacetraders/models/shipyard_ship_types_item.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.ship_type import ShipType
 from ..types import UNSET, Unset
@@ -20,45 +21,17 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="ShipyardShipTypesItem")
 
 
-@attr.s(auto_attribs=True)
-class ShipyardShipTypesItem:
+class ShipyardShipTypesItem(BaseModel):
     """
     Attributes:
         type (Union[Unset, ShipType]):
     """
 
     type: Union[Unset, ShipType] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        type: Union[Unset, str] = UNSET
-        if not isinstance(self.type, Unset):
-            type = self.type.value
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if type is not UNSET:
-            field_dict["type"] = type
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        _type = d.pop("type", UNSET)
-        type: Union[Unset, ShipType]
-        if isinstance(_type, Unset):
-            type = UNSET
-        else:
-            type = ShipType(_type)
-
-        shipyard_ship_types_item = cls(
-            type=type,
-        )
-
-        shipyard_ship_types_item.additional_properties = d
-        return shipyard_ship_types_item
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/shipyard_transaction.py
+++ b/spacetraders/models/shipyard_transaction.py
@@ -15,14 +15,14 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="ShipyardTransaction")
 
 
-@attr.s(auto_attribs=True)
-class ShipyardTransaction:
+class ShipyardTransaction(BaseModel):
     """
     Attributes:
         waypoint_symbol (str): The symbol of the waypoint where the transaction took place.
@@ -32,57 +32,15 @@ class ShipyardTransaction:
         timestamp (datetime.datetime): The timestamp of the transaction.
     """
 
-    waypoint_symbol: str
-    ship_symbol: str
-    price: int
-    agent_symbol: str
-    timestamp: datetime.datetime
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    waypoint_symbol: str = Field(alias="waypointSymbol")
+    ship_symbol: str = Field(alias="shipSymbol")
+    price: int = Field(alias="price")
+    agent_symbol: str = Field(alias="agentSymbol")
+    timestamp: datetime.datetime = Field(alias="timestamp")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        waypoint_symbol = self.waypoint_symbol
-        ship_symbol = self.ship_symbol
-        price = self.price
-        agent_symbol = self.agent_symbol
-        timestamp = self.timestamp.isoformat()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "waypointSymbol": waypoint_symbol,
-                "shipSymbol": ship_symbol,
-                "price": price,
-                "agentSymbol": agent_symbol,
-                "timestamp": timestamp,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        waypoint_symbol = d.pop("waypointSymbol")
-
-        ship_symbol = d.pop("shipSymbol")
-
-        price = d.pop("price")
-
-        agent_symbol = d.pop("agentSymbol")
-
-        timestamp = isoparse(d.pop("timestamp"))
-
-        shipyard_transaction = cls(
-            waypoint_symbol=waypoint_symbol,
-            ship_symbol=ship_symbol,
-            price=price,
-            agent_symbol=agent_symbol,
-            timestamp=timestamp,
-        )
-
-        shipyard_transaction.additional_properties = d
-        return shipyard_transaction
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/survey.py
+++ b/spacetraders/models/survey.py
@@ -15,19 +15,16 @@ from typing import (
 
 import attr
 from dateutil.parser import isoparse
+from pydantic import BaseModel, Field
 
+from ..models.survey_deposit import SurveyDeposit
 from ..models.survey_size import SurveySize
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.survey_deposit import SurveyDeposit
-
 
 T = TypeVar("T", bound="Survey")
 
 
-@attr.s(auto_attribs=True)
-class Survey:
+class Survey(BaseModel):
     """A resource survey of a waypoint, detailing a specific extraction location and the types of resources that can be
     found there.
 
@@ -42,72 +39,15 @@ class Survey:
                 before it is exhausted.
     """
 
-    signature: str
-    symbol: str
-    deposits: List["SurveyDeposit"]
-    expiration: datetime.datetime
-    size: SurveySize
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    signature: str = Field(alias="signature")
+    symbol: str = Field(alias="symbol")
+    deposits: List["SurveyDeposit"] = Field(alias="deposits")
+    expiration: datetime.datetime = Field(alias="expiration")
+    size: SurveySize = Field(alias="size")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.survey_deposit import SurveyDeposit
-
-        signature = self.signature
-        symbol = self.symbol
-        deposits = []
-        for deposits_item_data in self.deposits:
-            deposits_item = deposits_item_data.to_dict()
-
-            deposits.append(deposits_item)
-
-        expiration = self.expiration.isoformat()
-
-        size = self.size.value
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "signature": signature,
-                "symbol": symbol,
-                "deposits": deposits,
-                "expiration": expiration,
-                "size": size,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.survey_deposit import SurveyDeposit
-
-        d = src_dict.copy()
-        signature = d.pop("signature")
-
-        symbol = d.pop("symbol")
-
-        deposits = []
-        _deposits = d.pop("deposits")
-        for deposits_item_data in _deposits:
-            deposits_item = SurveyDeposit.from_dict(deposits_item_data)
-
-            deposits.append(deposits_item)
-
-        expiration = isoparse(d.pop("expiration"))
-
-        size = SurveySize(d.pop("size"))
-
-        survey = cls(
-            signature=signature,
-            symbol=symbol,
-            deposits=deposits,
-            expiration=expiration,
-            size=size,
-        )
-
-        survey.additional_properties = d
-        return survey
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/survey_deposit.py
+++ b/spacetraders/models/survey_deposit.py
@@ -12,47 +12,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="SurveyDeposit")
 
 
-@attr.s(auto_attribs=True)
-class SurveyDeposit:
+class SurveyDeposit(BaseModel):
     """A surveyed deposit of a mineral or resource available for extraction.
 
     Attributes:
         symbol (str): The symbol of the deposit.
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        survey_deposit = cls(
-            symbol=symbol,
-        )
-
-        survey_deposit.additional_properties = d
-        return survey_deposit
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/system.py
+++ b/spacetraders/models/system.py
@@ -13,20 +13,17 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.system_faction import SystemFaction
 from ..models.system_type import SystemType
+from ..models.system_waypoint import SystemWaypoint
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.system_faction import SystemFaction
-    from ..models.system_waypoint import SystemWaypoint
-
 
 T = TypeVar("T", bound="System")
 
 
-@attr.s(auto_attribs=True)
-class System:
+class System(BaseModel):
     """
     Attributes:
         symbol (str):
@@ -38,95 +35,17 @@ class System:
         factions (List['SystemFaction']):
     """
 
-    symbol: str
-    sector_symbol: str
-    type: SystemType
-    x: int
-    y: int
-    waypoints: List["SystemWaypoint"]
-    factions: List["SystemFaction"]
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    sector_symbol: str = Field(alias="sectorSymbol")
+    type: SystemType = Field(alias="type")
+    x: int = Field(alias="x")
+    y: int = Field(alias="y")
+    waypoints: List["SystemWaypoint"] = Field(alias="waypoints")
+    factions: List["SystemFaction"] = Field(alias="factions")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.system_faction import SystemFaction
-        from ..models.system_waypoint import SystemWaypoint
-
-        symbol = self.symbol
-        sector_symbol = self.sector_symbol
-        type = self.type.value
-
-        x = self.x
-        y = self.y
-        waypoints = []
-        for waypoints_item_data in self.waypoints:
-            waypoints_item = waypoints_item_data.to_dict()
-
-            waypoints.append(waypoints_item)
-
-        factions = []
-        for factions_item_data in self.factions:
-            factions_item = factions_item_data.to_dict()
-
-            factions.append(factions_item)
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "sectorSymbol": sector_symbol,
-                "type": type,
-                "x": x,
-                "y": y,
-                "waypoints": waypoints,
-                "factions": factions,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.system_faction import SystemFaction
-        from ..models.system_waypoint import SystemWaypoint
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        sector_symbol = d.pop("sectorSymbol")
-
-        type = SystemType(d.pop("type"))
-
-        x = d.pop("x")
-
-        y = d.pop("y")
-
-        waypoints = []
-        _waypoints = d.pop("waypoints")
-        for waypoints_item_data in _waypoints:
-            waypoints_item = SystemWaypoint.from_dict(waypoints_item_data)
-
-            waypoints.append(waypoints_item)
-
-        factions = []
-        _factions = d.pop("factions")
-        for factions_item_data in _factions:
-            factions_item = SystemFaction.from_dict(factions_item_data)
-
-            factions.append(factions_item)
-
-        system = cls(
-            symbol=symbol,
-            sector_symbol=sector_symbol,
-            type=type,
-            x=x,
-            y=y,
-            waypoints=waypoints,
-            factions=factions,
-        )
-
-        system.additional_properties = d
-        return system
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/system_faction.py
+++ b/spacetraders/models/system_faction.py
@@ -12,46 +12,24 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="SystemFaction")
 
 
-@attr.s(auto_attribs=True)
-class SystemFaction:
+class SystemFaction(BaseModel):
     """
     Attributes:
         symbol (str):
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        system_faction = cls(
-            symbol=symbol,
-        )
-
-        system_faction.additional_properties = d
-        return system_faction
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/system_waypoint.py
+++ b/spacetraders/models/system_waypoint.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.waypoint_type import WaypointType
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="SystemWaypoint")
 
 
-@attr.s(auto_attribs=True)
-class SystemWaypoint:
+class SystemWaypoint(BaseModel):
     """
     Attributes:
         symbol (str):
@@ -29,52 +29,14 @@ class SystemWaypoint:
         y (int):
     """
 
-    symbol: str
-    type: WaypointType
-    x: int
-    y: int
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    type: WaypointType = Field(alias="type")
+    x: int = Field(alias="x")
+    y: int = Field(alias="y")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-        type = self.type.value
-
-        x = self.x
-        y = self.y
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "type": type,
-                "x": x,
-                "y": y,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        type = WaypointType(d.pop("type"))
-
-        x = d.pop("x")
-
-        y = d.pop("y")
-
-        system_waypoint = cls(
-            symbol=symbol,
-            type=type,
-            x=x,
-            y=y,
-        )
-
-        system_waypoint.additional_properties = d
-        return system_waypoint
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/trade_good.py
+++ b/spacetraders/models/trade_good.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.trade_symbol import TradeSymbol
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="TradeGood")
 
 
-@attr.s(auto_attribs=True)
-class TradeGood:
+class TradeGood(BaseModel):
     """
     Attributes:
         symbol (TradeSymbol):
@@ -28,46 +28,13 @@ class TradeGood:
         description (str):
     """
 
-    symbol: TradeSymbol
-    name: str
-    description: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: TradeSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol.value
-
-        name = self.name
-        description = self.description
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = TradeSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        trade_good = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-        )
-
-        trade_good.additional_properties = d
-        return trade_good
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/transfer_cargo_transfer_cargo_200_response.py
+++ b/spacetraders/models/transfer_cargo_transfer_cargo_200_response.py
@@ -13,60 +13,27 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.transfer_cargo_transfer_cargo_200_response_data import (
+    TransferCargoTransferCargo200ResponseData,
+)
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.transfer_cargo_transfer_cargo_200_response_data import (
-        TransferCargoTransferCargo200ResponseData,
-    )
-
 
 T = TypeVar("T", bound="TransferCargoTransferCargo200Response")
 
 
-@attr.s(auto_attribs=True)
-class TransferCargoTransferCargo200Response:
+class TransferCargoTransferCargo200Response(BaseModel):
     """
     Attributes:
         data (TransferCargoTransferCargo200ResponseData):
     """
 
-    data: "TransferCargoTransferCargo200ResponseData"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "TransferCargoTransferCargo200ResponseData" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.transfer_cargo_transfer_cargo_200_response_data import (
-            TransferCargoTransferCargo200ResponseData,
-        )
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.transfer_cargo_transfer_cargo_200_response_data import (
-            TransferCargoTransferCargo200ResponseData,
-        )
-
-        d = src_dict.copy()
-        data = TransferCargoTransferCargo200ResponseData.from_dict(d.pop("data"))
-
-        transfer_cargo_transfer_cargo_200_response = cls(
-            data=data,
-        )
-
-        transfer_cargo_transfer_cargo_200_response.additional_properties = d
-        return transfer_cargo_transfer_cargo_200_response
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/transfer_cargo_transfer_cargo_200_response_data.py
+++ b/spacetraders/models/transfer_cargo_transfer_cargo_200_response_data.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_cargo import ShipCargo
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_cargo import ShipCargo
-
 
 T = TypeVar("T", bound="TransferCargoTransferCargo200ResponseData")
 
 
-@attr.s(auto_attribs=True)
-class TransferCargoTransferCargo200ResponseData:
+class TransferCargoTransferCargo200ResponseData(BaseModel):
     """
     Attributes:
         cargo (ShipCargo):
     """
 
-    cargo: "ShipCargo"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    cargo: "ShipCargo" = Field(alias="cargo")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_cargo import ShipCargo
-
-        cargo = self.cargo.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "cargo": cargo,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_cargo import ShipCargo
-
-        d = src_dict.copy()
-        cargo = ShipCargo.from_dict(d.pop("cargo"))
-
-        transfer_cargo_transfer_cargo_200_response_data = cls(
-            cargo=cargo,
-        )
-
-        transfer_cargo_transfer_cargo_200_response_data.additional_properties = d
-        return transfer_cargo_transfer_cargo_200_response_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/transfer_cargo_transfer_cargo_request.py
+++ b/spacetraders/models/transfer_cargo_transfer_cargo_request.py
@@ -12,14 +12,14 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TransferCargoTransferCargoRequest")
 
 
-@attr.s(auto_attribs=True)
-class TransferCargoTransferCargoRequest:
+class TransferCargoTransferCargoRequest(BaseModel):
     """
     Attributes:
         trade_symbol (str):
@@ -27,45 +27,13 @@ class TransferCargoTransferCargoRequest:
         ship_symbol (str):
     """
 
-    trade_symbol: str
-    units: int
-    ship_symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    trade_symbol: str = Field(alias="tradeSymbol")
+    units: int = Field(alias="units")
+    ship_symbol: str = Field(alias="shipSymbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        trade_symbol = self.trade_symbol
-        units = self.units
-        ship_symbol = self.ship_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "tradeSymbol": trade_symbol,
-                "units": units,
-                "shipSymbol": ship_symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        trade_symbol = d.pop("tradeSymbol")
-
-        units = d.pop("units")
-
-        ship_symbol = d.pop("shipSymbol")
-
-        transfer_cargo_transfer_cargo_request = cls(
-            trade_symbol=trade_symbol,
-            units=units,
-            ship_symbol=ship_symbol,
-        )
-
-        transfer_cargo_transfer_cargo_request.additional_properties = d
-        return transfer_cargo_transfer_cargo_request
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/warp_ship_json_body.py
+++ b/spacetraders/models/warp_ship_json_body.py
@@ -12,46 +12,24 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="WarpShipJsonBody")
 
 
-@attr.s(auto_attribs=True)
-class WarpShipJsonBody:
+class WarpShipJsonBody(BaseModel):
     """
     Attributes:
         waypoint_symbol (str): The target destination.
     """
 
-    waypoint_symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    waypoint_symbol: str = Field(alias="waypointSymbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        waypoint_symbol = self.waypoint_symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "waypointSymbol": waypoint_symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        waypoint_symbol = d.pop("waypointSymbol")
-
-        warp_ship_json_body = cls(
-            waypoint_symbol=waypoint_symbol,
-        )
-
-        warp_ship_json_body.additional_properties = d
-        return warp_ship_json_body
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/warp_ship_response_200.py
+++ b/spacetraders/models/warp_ship_response_200.py
@@ -13,54 +13,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.warp_ship_response_200_data import WarpShipResponse200Data
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.warp_ship_response_200_data import WarpShipResponse200Data
-
 
 T = TypeVar("T", bound="WarpShipResponse200")
 
 
-@attr.s(auto_attribs=True)
-class WarpShipResponse200:
+class WarpShipResponse200(BaseModel):
     """
     Attributes:
         data (WarpShipResponse200Data):
     """
 
-    data: "WarpShipResponse200Data"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    data: "WarpShipResponse200Data" = Field(alias="data")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.warp_ship_response_200_data import WarpShipResponse200Data
-
-        data = self.data.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "data": data,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.warp_ship_response_200_data import WarpShipResponse200Data
-
-        d = src_dict.copy()
-        data = WarpShipResponse200Data.from_dict(d.pop("data"))
-
-        warp_ship_response_200 = cls(
-            data=data,
-        )
-
-        warp_ship_response_200.additional_properties = d
-        return warp_ship_response_200
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/warp_ship_response_200_data.py
+++ b/spacetraders/models/warp_ship_response_200_data.py
@@ -13,19 +13,16 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.ship_fuel import ShipFuel
+from ..models.ship_nav import ShipNav
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.ship_fuel import ShipFuel
-    from ..models.ship_nav import ShipNav
-
 
 T = TypeVar("T", bound="WarpShipResponse200Data")
 
 
-@attr.s(auto_attribs=True)
-class WarpShipResponse200Data:
+class WarpShipResponse200Data(BaseModel):
     """
     Attributes:
         fuel (ShipFuel): Details of the ship's fuel tanks including how much fuel was consumed during the last transit
@@ -33,46 +30,12 @@ class WarpShipResponse200Data:
         nav (ShipNav): The navigation information of the ship.
     """
 
-    fuel: "ShipFuel"
-    nav: "ShipNav"
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    fuel: "ShipFuel" = Field(alias="fuel")
+    nav: "ShipNav" = Field(alias="nav")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.ship_fuel import ShipFuel
-        from ..models.ship_nav import ShipNav
-
-        fuel = self.fuel.to_dict()
-
-        nav = self.nav.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "fuel": fuel,
-                "nav": nav,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.ship_fuel import ShipFuel
-        from ..models.ship_nav import ShipNav
-
-        d = src_dict.copy()
-        fuel = ShipFuel.from_dict(d.pop("fuel"))
-
-        nav = ShipNav.from_dict(d.pop("nav"))
-
-        warp_ship_response_200_data = cls(
-            fuel=fuel,
-            nav=nav,
-        )
-
-        warp_ship_response_200_data.additional_properties = d
-        return warp_ship_response_200_data
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/waypoint.py
+++ b/spacetraders/models/waypoint.py
@@ -14,22 +14,19 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
+from ..models.chart import Chart
+from ..models.waypoint_faction import WaypointFaction
+from ..models.waypoint_orbital import WaypointOrbital
+from ..models.waypoint_trait import WaypointTrait
 from ..models.waypoint_type import WaypointType
 from ..types import UNSET, Unset
-
-if TYPE_CHECKING:
-    from ..models.chart import Chart
-    from ..models.waypoint_faction import WaypointFaction
-    from ..models.waypoint_orbital import WaypointOrbital
-    from ..models.waypoint_trait import WaypointTrait
-
 
 T = TypeVar("T", bound="Waypoint")
 
 
-@attr.s(auto_attribs=True)
-class Waypoint:
+class Waypoint(BaseModel):
     """A waypoint is a location that ships can travel to such as a Planet, Moon or Space Station.
 
     Attributes:
@@ -45,129 +42,19 @@ class Waypoint:
             agents.
     """
 
-    symbol: str
-    type: WaypointType
-    system_symbol: str
-    x: int
-    y: int
-    orbitals: List["WaypointOrbital"]
-    traits: List["WaypointTrait"]
+    symbol: str = Field(alias="symbol")
+    type: WaypointType = Field(alias="type")
+    system_symbol: str = Field(alias="systemSymbol")
+    x: int = Field(alias="x")
+    y: int = Field(alias="y")
+    orbitals: List["WaypointOrbital"] = Field(alias="orbitals")
+    traits: List["WaypointTrait"] = Field(alias="traits")
     faction: Union[Unset, "WaypointFaction"] = UNSET
     chart: Union[Unset, "Chart"] = UNSET
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        from ..models.chart import Chart
-        from ..models.waypoint_faction import WaypointFaction
-        from ..models.waypoint_orbital import WaypointOrbital
-        from ..models.waypoint_trait import WaypointTrait
-
-        symbol = self.symbol
-        type = self.type.value
-
-        system_symbol = self.system_symbol
-        x = self.x
-        y = self.y
-        orbitals = []
-        for orbitals_item_data in self.orbitals:
-            orbitals_item = orbitals_item_data.to_dict()
-
-            orbitals.append(orbitals_item)
-
-        traits = []
-        for traits_item_data in self.traits:
-            traits_item = traits_item_data.to_dict()
-
-            traits.append(traits_item)
-
-        faction: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.faction, Unset):
-            faction = self.faction.to_dict()
-
-        chart: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.chart, Unset):
-            chart = self.chart.to_dict()
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "type": type,
-                "systemSymbol": system_symbol,
-                "x": x,
-                "y": y,
-                "orbitals": orbitals,
-                "traits": traits,
-            }
-        )
-        if faction is not UNSET:
-            field_dict["faction"] = faction
-        if chart is not UNSET:
-            field_dict["chart"] = chart
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        from ..models.chart import Chart
-        from ..models.waypoint_faction import WaypointFaction
-        from ..models.waypoint_orbital import WaypointOrbital
-        from ..models.waypoint_trait import WaypointTrait
-
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        type = WaypointType(d.pop("type"))
-
-        system_symbol = d.pop("systemSymbol")
-
-        x = d.pop("x")
-
-        y = d.pop("y")
-
-        orbitals = []
-        _orbitals = d.pop("orbitals")
-        for orbitals_item_data in _orbitals:
-            orbitals_item = WaypointOrbital.from_dict(orbitals_item_data)
-
-            orbitals.append(orbitals_item)
-
-        traits = []
-        _traits = d.pop("traits")
-        for traits_item_data in _traits:
-            traits_item = WaypointTrait.from_dict(traits_item_data)
-
-            traits.append(traits_item)
-
-        _faction = d.pop("faction", UNSET)
-        faction: Union[Unset, WaypointFaction]
-        if isinstance(_faction, Unset):
-            faction = UNSET
-        else:
-            faction = WaypointFaction.from_dict(_faction)
-
-        _chart = d.pop("chart", UNSET)
-        chart: Union[Unset, Chart]
-        if isinstance(_chart, Unset):
-            chart = UNSET
-        else:
-            chart = Chart.from_dict(_chart)
-
-        waypoint = cls(
-            symbol=symbol,
-            type=type,
-            system_symbol=system_symbol,
-            x=x,
-            y=y,
-            orbitals=orbitals,
-            traits=traits,
-            faction=faction,
-            chart=chart,
-        )
-
-        waypoint.additional_properties = d
-        return waypoint
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/waypoint_faction.py
+++ b/spacetraders/models/waypoint_faction.py
@@ -12,46 +12,24 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="WaypointFaction")
 
 
-@attr.s(auto_attribs=True)
-class WaypointFaction:
+class WaypointFaction(BaseModel):
     """
     Attributes:
         symbol (str):
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        waypoint_faction = cls(
-            symbol=symbol,
-        )
-
-        waypoint_faction.additional_properties = d
-        return waypoint_faction
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/waypoint_orbital.py
+++ b/spacetraders/models/waypoint_orbital.py
@@ -12,47 +12,25 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="WaypointOrbital")
 
 
-@attr.s(auto_attribs=True)
-class WaypointOrbital:
+class WaypointOrbital(BaseModel):
     """An orbital is another waypoint that orbits a parent waypoint.
 
     Attributes:
         symbol (str):
     """
 
-    symbol: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: str = Field(alias="symbol")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = d.pop("symbol")
-
-        waypoint_orbital = cls(
-            symbol=symbol,
-        )
-
-        waypoint_orbital.additional_properties = d
-        return waypoint_orbital
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:

--- a/spacetraders/models/waypoint_trait.py
+++ b/spacetraders/models/waypoint_trait.py
@@ -12,6 +12,7 @@ from typing import (
 )
 
 import attr
+from pydantic import BaseModel, Field
 
 from ..models.waypoint_trait_symbol import WaypointTraitSymbol
 from ..types import UNSET, Unset
@@ -19,8 +20,7 @@ from ..types import UNSET, Unset
 T = TypeVar("T", bound="WaypointTrait")
 
 
-@attr.s(auto_attribs=True)
-class WaypointTrait:
+class WaypointTrait(BaseModel):
     """
     Attributes:
         symbol (WaypointTraitSymbol): The unique identifier of the trait.
@@ -28,46 +28,13 @@ class WaypointTrait:
         description (str): A description of the trait.
     """
 
-    symbol: WaypointTraitSymbol
-    name: str
-    description: str
-    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+    symbol: WaypointTraitSymbol = Field(alias="symbol")
+    name: str = Field(alias="name")
+    description: str = Field(alias="description")
+    additional_properties: Dict[str, Any] = {}
 
-    def to_dict(self) -> Dict[str, Any]:
-        symbol = self.symbol.value
-
-        name = self.name
-        description = self.description
-
-        field_dict: Dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "symbol": symbol,
-                "name": name,
-                "description": description,
-            }
-        )
-
-        return field_dict
-
-    @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
-        d = src_dict.copy()
-        symbol = WaypointTraitSymbol(d.pop("symbol"))
-
-        name = d.pop("name")
-
-        description = d.pop("description")
-
-        waypoint_trait = cls(
-            symbol=symbol,
-            name=name,
-            description=description,
-        )
-
-        waypoint_trait.additional_properties = d
-        return waypoint_trait
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def additional_keys(self) -> List[str]:


### PR DESCRIPTION
This is a breaking change but allows a more reasonable approach to interacting with the API

Before:

```python
from spacetraders import Client
from spacetraders.models.register_json_body import RegisterJsonBody
from spacetraders.models.register_json_body_faction import RegisterJsonBodyFaction

client = Client(base_url="https://api.spacetraders.io/v2")
register_body = RegisterJsonBody(symbol="Marco-Test", faction=RegisterJsonBodyFaction.COSMIC)
resp = client.default.register(json_body=register_body)
print(resp)
```

After:

```python
from spacetraders import Client

client = Client(base_url="https://api.spacetraders.io/v2")
resp = client.default.register(faction="COSMIC", symbol="marco-test")
print(resp)
```

This doesn't resolve type-hinting, but changes `json_body` to be `**json_body` and adds a normalize step in the body of each method. openapi-python-client doesn't seem to directly expose a way to interrogate the model properties, only the model name from the template. This means we'll need more work to get the TypeHinting correct though even now it's not wired up due to how APIStub works. I'll tackle the APIStub issue in another update.